### PR TITLE
Use cache for docker image build

### DIFF
--- a/.github/workflows/gitops.yml
+++ b/.github/workflows/gitops.yml
@@ -45,14 +45,26 @@ jobs:
             IMAGE_TAG=${{ github.head_ref }}
           fi
 
+          CACHE_BASE=$ECR_REGISTRY/$ECR_REPOSITORY:base-cache
+          CACHE_BUILD=$ECR_REGISTRY/$ECR_REPOSITORY:build-cache
+
           IMAGE_WITH_TAG=$ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG
           IMAGE_WITH_SHA=$ECR_REGISTRY/$ECR_REPOSITORY:${{ github.sha }}
 
-          docker build -t $IMAGE_WITH_TAG .
-          docker push $IMAGE_WITH_TAG
+          docker build \
+            --cache-from=$CACHE_BASE \
+            --cache-from=$CACHE_BUILD \
+            --build-arg=BUILDKIT_INLINE_CACHE=1 \
+            -t $IMAGE_WITH_TAG \
+            -t $IMAGE_WITH_SHA .
+
+          docker build --target base -t $CACHE_BASE --build-arg=BUILDKIT_INLINE_CACHE=1  .
+          docker build --target build -t $CACHE_BUILD --build-arg=BUILDKIT_INLINE_CACHE=1  .
 
           docker tag $IMAGE_WITH_TAG $IMAGE_WITH_SHA
           docker push $IMAGE_WITH_SHA
+          docker push $CACHE_BASE
+          docker push $CACHE_BUILD
 
           echo "::set-output name=IMAGE_TAG::${IMAGE_TAG}"
           echo "::set-output name=IMAGE_WITH_TAG::${IMAGE_WITH_TAG}"


### PR DESCRIPTION
いつぞやの配信を拝見dockerイメージのビルドにキャッシュを使うようにしてみました。

* 現状2分台でCIが終了している事
* 手元で簡易的な動確はしましたが、環境依存含めてほんとうにこれで大丈夫かは確認が必要な事
が懸念としてあります。
Contributeの規約が無かった為勢いでプルリク送らさせて頂きましたが、問題あれば遠慮無く閉じて下さって大丈夫です!