### PR TITLE
remove Warning: Failed prop type

### DIFF
--- a/src/components/Track.tsx
+++ b/src/components/Track.tsx
@@ -61,9 +61,6 @@ const TrackView: React.FC<Props> = ({ selectedTrackId, propTalks }) => {
         xs={12}
         md={8}
         className={classes.player}
-        justify="center"
-        alignItems="center"
-        alignContent="center"
       >
         <Player vimeoId={selectedTalk?.videoId} autoplay={false}></Player>
       </Grid>
@@ -72,9 +69,6 @@ const TrackView: React.FC<Props> = ({ selectedTrackId, propTalks }) => {
         xs={12}
         md={3}
         className={classes.chat}
-        justify="center"
-        alignItems="center"
-        alignContent="center"
       >
         <Chat talk={selectedTalk} />
       </Grid>
@@ -83,9 +77,6 @@ const TrackView: React.FC<Props> = ({ selectedTrackId, propTalks }) => {
         xs={12}
         md={8}
         className={classes.player}
-        justify="center"
-        alignItems="center"
-        alignContent="center"
       >
         <TalkInfo selectedTalk={selectedTalk} />
       </Grid>

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -49,9 +49,6 @@ const IndexPage: React.FC = () => {
           xs={12}
           md={8}
           className={classes.debug}
-          justify="center"
-          alignItems="center"
-          alignContent="center"
         >
           <TrackSelector
             tracks={tracks}
@@ -59,7 +56,7 @@ const IndexPage: React.FC = () => {
             selectTrack={selectTrack}
           />
         </Grid>
-        <Grid item xs={12} md={12} className={classes.debug} justify="center">
+        <Grid item xs={12} md={12} className={classes.debug}>
           <TrackView selectedTrackId={selectedTrackId} />
         </Grid>
       </Grid>


### PR DESCRIPTION
以下のようなwarningを消します（が、これでいいのかはわかっていません…）

```
Warning: Failed prop type: The prop `alignItems` of `Grid` must be used on `container`.
```