### PR TITLE
チャットが更新されなくなることがある問題の対応

### DIFF
--- a/src/components/Chat/Chat.tsx
+++ b/src/components/Chat/Chat.tsx
@@ -84,7 +84,7 @@ export const Chat: React.FC<Props> = ({ talk }) => {
       receivedMsg.replyTo,
     )
     messages.addMessage(msg)
-    setMessages(messages)
+    setMessages(new ChatMessageMap(messages))
   }
 
   useEffect(() => {


### PR DESCRIPTION
webSocket経由でチャットメッセージを受け取ってsetMessagesする際にnewChatMessageMapするように変更。
なお、初回レンダリング時にAPIから取得する際も同じ方法を使っている