### PR TITLE
発表終了した動画ではChatに新規書き込みできないようにする

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
         "@types/moment": "^2.13.0",
         "actioncable": "^5.2.4-5",
         "axios": "^0.21.1",
+        "dayjs": "^1.10.4",
         "linkifyjs": "^2.1.9",
         "moment": "^2.29.1",
         "next": "latest",

--- a/src/components/Chat/Chat.tsx
+++ b/src/components/Chat/Chat.tsx
@@ -49,8 +49,8 @@ export const Chat: React.FC<Props> = ({ talk }) => {
     initialChatMessage,
   )
   const [chatCable, setChatCable] = useState<ActionCable.Cable | null>(null)
-
-  const isArchive = dayjs().unix() - dayjs(talk?.endTime).unix() >= 0
+  // 発表時間の幅を考慮して10分(6000000ミリ秒)余裕をもたせる
+  const isArchive = dayjs().unix() - dayjs(talk?.endTime).unix() >= 6000000
   const actionCableUrl = () => {
     if (window.location.protocol == 'http:') {
       return `ws://${window.location.host}/cable`

--- a/src/components/Chat/Chat.tsx
+++ b/src/components/Chat/Chat.tsx
@@ -8,6 +8,7 @@ import {
 } from '../../client-axios'
 import { ChatMessageForm } from './internal/ChatMessageForm'
 import ActionCable from 'actioncable'
+import dayjs from 'dayjs'
 import { ChatMessageClass, ChatMessageMap } from '../../util/chat'
 import { TabContext } from '@material-ui/lab'
 import { ChatBox } from './internal/ChatBox'
@@ -48,6 +49,8 @@ export const Chat: React.FC<Props> = ({ talk }) => {
     initialChatMessage,
   )
   const [chatCable, setChatCable] = useState<ActionCable.Cable | null>(null)
+
+  const isArchive = dayjs().unix() - dayjs(talk?.endTime).unix() >= 0
   const actionCableUrl = () => {
     if (window.location.protocol == 'http:') {
       return `ws://${window.location.host}/cable`
@@ -206,6 +209,7 @@ export const Chat: React.FC<Props> = ({ talk }) => {
           </Styled.TabPanel>
         </TabContext>
         <ChatMessageForm
+          isArchive={isArchive}
           selectedMessage={selectedMessage}
           onClickCloseButton={onClickCloseButton}
           onSendMessage={onSendReply}

--- a/src/components/Chat/internal/ChatMessageForm/ChatMessageForm.tsx
+++ b/src/components/Chat/internal/ChatMessageForm/ChatMessageForm.tsx
@@ -8,12 +8,14 @@ import { MessageInputs } from '../ChatMessageRequest'
 
 type Props = {
   selectedMessage: ChatMessageClass
+  isArchive: boolean
   onClickCloseButton: () => void
   onSendMessage: (data: MessageInputs) => void
   onSendQuestion: (data: MessageInputs) => void
 }
 
 export const ChatMessageForm: React.FC<Props> = ({
+  isArchive,
   onSendMessage,
   onSendQuestion,
 }) => {
@@ -35,37 +37,39 @@ export const ChatMessageForm: React.FC<Props> = ({
 
   return (
     <Styled.Container>
-      <Styled.ChatMessageForm>
-        <Styled.TextField
-          name="chatMessage"
-          color="secondary"
-          size="small"
-          inputRef={register}
-          multiline
-        />
-        <Input type="hidden" name="isQuestion" inputRef={register} />
-        <Styled.ButtonContainer>
-          <ReactionButton reactEmoji="👍" onSendReply={onSendMessage} />
-          <ReactionButton reactEmoji="👏" onSendReply={onSendMessage} />
-          <ReactionButton reactEmoji="🎉" onSendReply={onSendMessage} />
-          <Button
-            type="submit"
-            disabled={!watchChatMessage}
-            variant="contained"
-            onClick={handleSubmit(onSendMessage)}
-          >
-            送信
-          </Button>
-          <Button
-            type="submit"
-            disabled={!watchChatMessage}
-            variant="contained"
-            onClick={handleSubmit(onSendQuestion)}
-          >
-            質問する
-          </Button>
-        </Styled.ButtonContainer>
-      </Styled.ChatMessageForm>
+      {isArchive && (
+        <Styled.ChatMessageForm>
+          <Styled.TextField
+            name="chatMessage"
+            color="secondary"
+            size="small"
+            inputRef={register}
+            multiline
+          />
+          <Input type="hidden" name="isQuestion" inputRef={register} />
+          <Styled.ButtonContainer>
+            <ReactionButton reactEmoji="👍" onSendReply={onSendMessage} />
+            <ReactionButton reactEmoji="👏" onSendReply={onSendMessage} />
+            <ReactionButton reactEmoji="🎉" onSendReply={onSendMessage} />
+            <Button
+              type="submit"
+              disabled={!watchChatMessage}
+              variant="contained"
+              onClick={handleSubmit(onSendMessage)}
+            >
+              送信
+            </Button>
+            <Button
+              type="submit"
+              disabled={!watchChatMessage}
+              variant="contained"
+              onClick={handleSubmit(onSendQuestion)}
+            >
+              質問する
+            </Button>
+          </Styled.ButtonContainer>
+        </Styled.ChatMessageForm>
+      )}
     </Styled.Container>
   )
 }

--- a/src/components/Chat/internal/ChatMessageForm/styled.ts
+++ b/src/components/Chat/internal/ChatMessageForm/styled.ts
@@ -5,6 +5,7 @@ export const Container = styled.div`
   background-color: #fff;
   border-top: 1px solid lightgray;
   border-radius: 0 0 10px 10px;
+  min-height: 20px;
 `
 
 export const ChatMessage = styled(Paper)<{ isChat: boolean }>`

--- a/yarn.lock
+++ b/yarn.lock
@@ -2580,6 +2580,11 @@ data-urls@^2.0.0:
     whatwg-mimetype "^2.3.0"
     whatwg-url "^8.0.0"
 
+dayjs@^1.10.4:
+  version "1.10.4"
+  resolved "https://registry.yarnpkg.com/dayjs/-/dayjs-1.10.4.tgz#8e544a9b8683f61783f570980a8a80eaf54ab1e2"
+  integrity sha512-RI/Hh4kqRc1UKLOAf/T5zdMMX5DQIlDxwUe3wSyMMnEbGunnpENCdbUgM+dW7kXidZqCttBrmw7BhN4TMddkCw==
+
 debug@4, debug@^4.0.1, debug@^4.1.0, debug@^4.1.1, debug@^4.2.0:
   version "4.3.1"
   resolved "https://registry.yarnpkg.com/debug/-/debug-4.3.1.tgz#f0d229c505e0c6d8c49ac553d1b13dc183f6b2ee"


### PR DESCRIPTION
ref #73

* 終了した動画のChat欄は閉鎖する
* 登壇者が質問にあとから答えたいパターンも考慮して返信は可能のまま

<img width="350" alt="スクリーンショット 2021-03-01 22 48 50" src="https://user-images.githubusercontent.com/11240481/109505927-6faffe80-7ae0-11eb-8bbb-6a6e57d75a6f.png">
