### PR TITLE
Fadeやめて縦スクロールにした

### DIFF
--- a/src/components/Sponsors/Sponsors.tsx
+++ b/src/components/Sponsors/Sponsors.tsx
@@ -10,7 +10,6 @@ export const Sponsors: React.FC = () => {
     slidesPerRow: 3,
     slidesToScroll: 1,
     vertical: true,
-    fade: true,
     autoplay: true,
     speed: 800,
     autoplaySpeed: 8000,


### PR DESCRIPTION
Fix #95
Fadeにするとスポンサーロゴがクリックできない問題が発覚。
とりあえずFade消したらクリックできるようになった。

横スクロールにあった不安定なスクロール挙動は今のところ見受けられないのでこれで