### PR TITLE
release用PRであることを判別する要素を label から title に変更

### DIFF
--- a/.github/workflows/eslint.yml
+++ b/.github/workflows/eslint.yml
@@ -6,6 +6,7 @@ jobs:
   eslint:
     name: eslint
     runs-on: ubuntu-latest
+    if: ${{ ! contains(github.event.pull_request.title, '[dreamkast-releasebot]') }}
     steps:
       - uses: actions/checkout@v1
       - name: yarn install

--- a/.github/workflows/gc.yaml
+++ b/.github/workflows/gc.yaml
@@ -9,10 +9,7 @@ on:
 jobs:
   push:
     runs-on: ubuntu-latest
-    if: >-
-      ! contains(github.event.pull_request.labels.*.name, 'release/major') &&
-      ! contains(github.event.pull_request.labels.*.name, 'release/minor') &&
-      ! contains(github.event.pull_request.labels.*.name, 'release/patch')
+    if: ${{ ! contains(github.event.pull_request.title, '[dreamkast-releasebot]') }}
     steps:
       - uses: actions/checkout@v2
 

--- a/.github/workflows/gitops-dev.yml
+++ b/.github/workflows/gitops-dev.yml
@@ -9,10 +9,7 @@ on:
 jobs:
   gitops:
     runs-on: ubuntu-latest
-    if: >-
-      ! contains(github.event.pull_request.labels.*.name, 'release/major') &&
-      ! contains(github.event.pull_request.labels.*.name, 'release/minor') &&
-      ! contains(github.event.pull_request.labels.*.name, 'release/patch')
+    if: ${{ ! contains(github.event.pull_request.title, '[dreamkast-releasebot]') }}
     steps:
       - uses: actions/checkout@v2
 

--- a/.github/workflows/jest.yml
+++ b/.github/workflows/jest.yml
@@ -6,6 +6,7 @@ jobs:
   jest:
     name: jest
     runs-on: ubuntu-latest
+    if: ${{ ! contains(github.event.pull_request.title, '[dreamkast-releasebot]') }}
     steps:
       - uses: actions/checkout@v1
       - name: yarn install

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,10 +7,7 @@ on:
 jobs:
   release:
     runs-on: ubuntu-latest
-    if: >-
-      contains(github.event.pull_request.labels.*.name, 'release/major') ||
-      contains(github.event.pull_request.labels.*.name, 'release/minor') ||
-      contains(github.event.pull_request.labels.*.name, 'release/patch')
+    if: ${{ contains(github.event.pull_request.title, '[dreamkast-releasebot]') }}
     steps:
       - uses: actions/checkout@v2
 


### PR DESCRIPTION
調べた限り GitHub API だと PullRequest 作成と label 付与を同時に出来無さそうだったので、 PR title で From bot であるかどうかを判別するようにしました

参考: https://github.com/cloudnativedaysjp/dreamkast-ui/pull/105