### PR TITLE
見た目いろいろ調整

### DIFF
--- a/src/components/BoothPage/BoothPage.tsx
+++ b/src/components/BoothPage/BoothPage.tsx
@@ -8,6 +8,7 @@ import {
 import * as Styled from './styled'
 import * as CommonStyled from '../../styles/styled'
 import { Grid } from '@material-ui/core'
+import { Button } from '@material-ui/core'
 import AttachmentPdfs from './internal/AttachmentPdfs'
 import { AttachmentImages } from './internal/AttachmentImages/AttachmentImages'
 import { Booths } from '../Booths'
@@ -113,9 +114,16 @@ export const BoothPage: React.FC<Props> = ({ boothId }) => {
               <CommonStyled.Header2 centerized={true}>
                 オンラインホワイトボード
               </CommonStyled.Header2>
-              <CommonStyled.Header3 centerized={true}>
-                (編集するには、左下のリンクをクリック)
-              </CommonStyled.Header3>
+              <CommonStyled.CenterizedContainer>
+                <CommonStyled.MenuLink href={`https://miro.com/app/board/${booth?.miroUrl}/`}>
+                <Button
+                  variant="contained"
+                  color="secondary"
+                >
+                  参加する
+                </Button>
+                </CommonStyled.MenuLink>
+              </CommonStyled.CenterizedContainer>
               <Miro
                 miroId={booth?.miroUrl}
                 liveEmbed={false}

--- a/src/components/BoothPage/BoothPage.tsx
+++ b/src/components/BoothPage/BoothPage.tsx
@@ -6,10 +6,12 @@ import {
   Configuration,
 } from '../../client-axios'
 import * as Styled from './styled'
+import * as CommonStyled from '../../styles/styled'
 import { Grid } from '@material-ui/core'
 import AttachmentPdfs from './internal/AttachmentPdfs'
 import { AttachmentImages } from './internal/AttachmentImages/AttachmentImages'
 import { Booths } from '../Booths'
+import { Miro } from '../../components/Miro'
 
 type Props = {
   boothId?: string
@@ -80,53 +82,45 @@ export const BoothPage: React.FC<Props> = ({ boothId }) => {
     getBooth()
   }, [boothId])
 
-  const miroEmbedUrl = (id?: string) => {
-    if (!id) return
-    return 'https://miro.com/app/embed/' + id + '/?autoplay=yep'
-  }
-
   return (
-    <Styled.BoothPageContainer
+    <CommonStyled.OuterContainer
       container
       spacing={1}
       alignItems="center"
       justify="center"
     >
       <Grid item xs={12} md={11}>
-        <Styled.Container>
+        <CommonStyled.Container>
           <Grid item xs={12}>
-            <Styled.CenterContainer>
+            <CommonStyled.CenterizedContainer>
               <Styled.LogoImg src={booth?.logoUrl} />
-            </Styled.CenterContainer>
-            <Styled.CenterContainer>
-              <h3>{booth?.sponsorName}</h3>
-            </Styled.CenterContainer>
+            </CommonStyled.CenterizedContainer>
+            <CommonStyled.Header2 centerized={true}>
+              {booth?.sponsorName}
+            </CommonStyled.Header2>
             <p>{booth?.description}</p>
           </Grid>
 
           <AttachmentImages images={booth?.keyImageUrls} />
           <Grid item xs={12}>
-            <Styled.CenterContainer>
+            <CommonStyled.CenterizedContainer>
               <p>{booth?.text}</p>
-            </Styled.CenterContainer>
+            </CommonStyled.CenterizedContainer>
           </Grid>
 
           {booth?.miroUrl && (
             <Grid item xs={12}>
-              <Styled.HeaderContainer>
-                <Styled.HeaderTitle>
-                  オンラインホワイトボード
-                  (編集するには、左下のリンクをクリック)
-                </Styled.HeaderTitle>
-              </Styled.HeaderContainer>
-              <Styled.CenterContainer>
-                <Styled.MiroIframe
-                  src={miroEmbedUrl(booth?.miroUrl)}
-                  frameBorder="0"
-                  scrolling="no"
-                  allowFullScreen
-                ></Styled.MiroIframe>
-              </Styled.CenterContainer>
+              <CommonStyled.Header2 centerized={true}>
+                オンラインホワイトボード
+              </CommonStyled.Header2>
+              <CommonStyled.Header3 centerized={true}>
+                (編集するには、左下のリンクをクリック)
+              </CommonStyled.Header3>
+              <Miro
+                miroId={booth?.miroUrl}
+                liveEmbed={false}
+                viewport="moveToViewport=-94,-1521,7088,5264"
+              />
             </Grid>
           )}
           {booth?.vimeoUrl && (
@@ -145,17 +139,17 @@ export const BoothPage: React.FC<Props> = ({ boothId }) => {
           )}
           {booth?.pdfUrls && (
             <Grid item xs={12}>
-              <Styled.HeaderContainer>
-                <Styled.HeaderTitle>PDF資料ダウンロード</Styled.HeaderTitle>
-              </Styled.HeaderContainer>
+              <CommonStyled.Header2 centerized={true}>
+                PDF資料ダウンロード
+              </CommonStyled.Header2>
               <AttachmentPdfs pdfs={booth?.pdfUrls} />
             </Grid>
           )}
-        </Styled.Container>
+        </CommonStyled.Container>
       </Grid>
       <Grid item xs={12} md={11}>
         <Booths openNewWindow={false} />
       </Grid>
-    </Styled.BoothPageContainer>
+    </CommonStyled.OuterContainer>
   )
 }

--- a/src/components/BoothPage/styled.ts
+++ b/src/components/BoothPage/styled.ts
@@ -5,28 +5,10 @@ export const BoothPageContainer = styled(Grid)`
   height: 100%;
 `
 
-export const Container = styled.div`
-  height: 100%;
-  background: rgba(255, 255, 255, 0.7);
-  font-size: 1.2em;
-  border-radius: 10px;
-  margin: 5px;
-  padding: 10px;
-`
-
-export const CenterContainer = styled.div`
-  width: 100%;
-  text-align: center;
-`
-
 export const LogoImg = styled.img`
   width: auto;
   max-width: 100%;
   max-height: 200px;
-`
-
-export const HeaderContainer = styled.div`
-  text-align: center;
 `
 
 export const VimeoContainer = styled.div`
@@ -49,15 +31,6 @@ export const KeyImage = styled.img`
   margin: auto;
 `
 
-export const MiroIframe = styled.iframe`
-  width: 100%;
-  min-height: 500px;
-`
-
 export const PdfContainer = styled.div`
   text-align: center;
-`
-
-export const HeaderTitle = styled.h2`
-  color: #037f8c;
 `

--- a/src/components/Booths/Booths.tsx
+++ b/src/components/Booths/Booths.tsx
@@ -2,6 +2,7 @@ import React, { useEffect, useState } from 'react'
 import { Configuration, Sponsor, SponsorApi } from '../../client-axios'
 import * as Styled from './styled'
 import { Grid } from '@material-ui/core'
+import * as CommonStyled from '../../styles/styled'
 
 type Props = {
   openNewWindow?: boolean
@@ -34,7 +35,7 @@ export const Booths: React.FC<Props> = ({ openNewWindow }) => {
 
   return (
     <Styled.Container>
-      <Styled.SponsorHeader>Booths</Styled.SponsorHeader>
+      <CommonStyled.Header2 centerized={true}>Booths</CommonStyled.Header2>
       <Grid container spacing={1} justify="center" alignItems="flex-start">
         {data.map((sponsor) => {
           if (sponsor.booth && sponsor.booth.id && sponsor.booth.opened) {

--- a/src/components/Booths/styled.ts
+++ b/src/components/Booths/styled.ts
@@ -11,11 +11,6 @@ export const Container = styled.div`
     display: none;
   }
 `
-export const SponsorHeader = styled.h2`
-  font-size: 2em;
-  text-align: center;
-  color: #037f8c;
-`
 
 export const Content = styled.div`
   padding: 10px 0;

--- a/src/components/Chat/styled.ts
+++ b/src/components/Chat/styled.ts
@@ -3,7 +3,7 @@ import { TabPanel as MUITabPanel } from '@material-ui/lab'
 import { Tabs, Tab as MUITab } from '@material-ui/core'
 
 export const Outer = styled.div`
-  padding: 5px;
+  padding: 5px 5px 5px 0;
 `
 
 export const Container = styled.div`

--- a/src/components/Layout/Layout.tsx
+++ b/src/components/Layout/Layout.tsx
@@ -17,7 +17,7 @@ export const Layout: React.FC<Props> = ({
 
   useEffect(() => {
     if (typeof window !== 'undefined') {
-      setUrl(`${window.location.href.replace('/cndo2021/ui', '/logout')}`)
+      setUrl(window.location.origin + '/logout')
     }
   }, [])
 
@@ -32,7 +32,7 @@ export const Layout: React.FC<Props> = ({
       <header>
         <AppBar position="static">
           <Styled.Header>
-            <a href="/cndo2021" target="_blank" rel="noopener noreferrer">
+            <a href="/cndo2021/ui" rel="noopener noreferrer">
               <Styled.HeaderImg src="/cndo2021/ui/images/CNDO2021_horizontal.png" />
             </a>
             <DesktopMenu url={url} />

--- a/src/components/Layout/__tests__/__snapshots__/Layout.spec.tsx.snap
+++ b/src/components/Layout/__tests__/__snapshots__/Layout.spec.tsx.snap
@@ -12,9 +12,8 @@ exports[`Layout 1`] = `
         className="MuiToolbar-root MuiToolbar-regular sc-gsTCUz kEloeC MuiToolbar-gutters"
       >
         <a
-          href="/cndo2021"
+          href="/cndo2021/ui"
           rel="noopener noreferrer"
-          target="_blank"
         >
           <img
             className="sc-dlfnbm jFXkDF"
@@ -60,9 +59,42 @@ exports[`Layout 1`] = `
           </a>
           <a
             className="sc-hBEYos bSCtY"
+            href="/cndo2021/ui/discussionboard"
+            rel="noreferrer"
+          >
+            <button
+              className="MuiButtonBase-root MuiButton-root MuiButton-text"
+              disabled={false}
+              onBlur={[Function]}
+              onDragLeave={[Function]}
+              onFocus={[Function]}
+              onKeyDown={[Function]}
+              onKeyUp={[Function]}
+              onMouseDown={[Function]}
+              onMouseLeave={[Function]}
+              onMouseUp={[Function]}
+              onTouchEnd={[Function]}
+              onTouchMove={[Function]}
+              onTouchStart={[Function]}
+              style={
+                Object {
+                  "color": "#037f8c",
+                }
+              }
+              tabIndex={0}
+              type="button"
+            >
+              <span
+                className="MuiButton-label"
+              >
+                DiscussionBoard
+              </span>
+            </button>
+          </a>
+          <a
+            className="sc-hBEYos bSCtY"
             href="/cndo2021/timetables"
             rel="noreferrer"
-            target="_blank"
           >
             <button
               className="MuiButtonBase-root MuiButton-root MuiButton-text"
@@ -158,6 +190,41 @@ exports[`Layout 1`] = `
               className="MuiButton-label"
             >
               Booths
+            </span>
+          </button>
+        </a>
+        <a
+          className="sc-hBEYos bSCtY"
+          href="/cndo2021/ui/discussionboard"
+          rel="noreferrer"
+          target="_blank"
+        >
+          <button
+            className="MuiButtonBase-root MuiButton-root MuiButton-text"
+            disabled={false}
+            onBlur={[Function]}
+            onDragLeave={[Function]}
+            onFocus={[Function]}
+            onKeyDown={[Function]}
+            onKeyUp={[Function]}
+            onMouseDown={[Function]}
+            onMouseLeave={[Function]}
+            onMouseUp={[Function]}
+            onTouchEnd={[Function]}
+            onTouchMove={[Function]}
+            onTouchStart={[Function]}
+            style={
+              Object {
+                "color": "#037f8c",
+              }
+            }
+            tabIndex={0}
+            type="button"
+          >
+            <span
+              className="MuiButton-label"
+            >
+              DiscussionBoard
             </span>
           </button>
         </a>

--- a/src/components/Layout/__tests__/__snapshots__/Layout.spec.tsx.snap
+++ b/src/components/Layout/__tests__/__snapshots__/Layout.spec.tsx.snap
@@ -224,7 +224,7 @@ exports[`Layout 1`] = `
             <span
               className="MuiButton-label"
             >
-              DiscussionBoard
+              Discussion
             </span>
           </button>
         </a>

--- a/src/components/Layout/__tests__/__snapshots__/Layout.spec.tsx.snap
+++ b/src/components/Layout/__tests__/__snapshots__/Layout.spec.tsx.snap
@@ -21,10 +21,10 @@ exports[`Layout 1`] = `
           />
         </a>
         <div
-          className="sc-fodVxV dfccac"
+          className="sc-hBEYos ipAVxb"
         >
           <a
-            className="sc-hBEYos bSCtY"
+            className="sc-kfzAmx dLIGSx"
             href="/cndo2021/ui#booths"
             rel="noreferrer"
           >
@@ -58,7 +58,7 @@ exports[`Layout 1`] = `
             </button>
           </a>
           <a
-            className="sc-hBEYos bSCtY"
+            className="sc-kfzAmx dLIGSx"
             href="/cndo2021/ui/discussionboard"
             rel="noreferrer"
           >
@@ -92,7 +92,7 @@ exports[`Layout 1`] = `
             </button>
           </a>
           <a
-            className="sc-hBEYos bSCtY"
+            className="sc-kfzAmx dLIGSx"
             href="/cndo2021/timetables"
             rel="noreferrer"
           >
@@ -157,10 +157,10 @@ exports[`Layout 1`] = `
         </div>
       </div>
       <div
-        className="sc-fFubgz bXZJlt"
+        className="sc-fodVxV gJEXNK"
       >
         <a
-          className="sc-hBEYos bSCtY"
+          className="sc-kfzAmx dLIGSx"
           href="/cndo2021/ui#booths"
           rel="noreferrer"
         >
@@ -194,7 +194,7 @@ exports[`Layout 1`] = `
           </button>
         </a>
         <a
-          className="sc-hBEYos bSCtY"
+          className="sc-kfzAmx dLIGSx"
           href="/cndo2021/ui/discussionboard"
           rel="noreferrer"
         >
@@ -228,7 +228,7 @@ exports[`Layout 1`] = `
           </button>
         </a>
         <a
-          className="sc-hBEYos bSCtY"
+          className="sc-kfzAmx dLIGSx"
           href="/cndo2021/timetables"
           rel="noreferrer"
         >

--- a/src/components/Layout/__tests__/__snapshots__/Layout.spec.tsx.snap
+++ b/src/components/Layout/__tests__/__snapshots__/Layout.spec.tsx.snap
@@ -197,7 +197,6 @@ exports[`Layout 1`] = `
           className="sc-hBEYos bSCtY"
           href="/cndo2021/ui/discussionboard"
           rel="noreferrer"
-          target="_blank"
         >
           <button
             className="MuiButtonBase-root MuiButton-root MuiButton-text"
@@ -232,7 +231,6 @@ exports[`Layout 1`] = `
           className="sc-hBEYos bSCtY"
           href="/cndo2021/timetables"
           rel="noreferrer"
-          target="_blank"
         >
           <button
             className="MuiButtonBase-root MuiButton-root MuiButton-text"

--- a/src/components/Menu/DesktopMenu.tsx
+++ b/src/components/Menu/DesktopMenu.tsx
@@ -12,11 +12,10 @@ export const DesktopMenu: React.FC<Props> = ({ url }) => {
       <Styled.MenuLink href="/cndo2021/ui#booths" rel="noreferrer">
         <Button style={{ color: '#037f8c' }}>Booths</Button>
       </Styled.MenuLink>
-      <Styled.MenuLink
-        href="/cndo2021/timetables"
-        target="_blank"
-        rel="noreferrer"
-      >
+      <Styled.MenuLink href="/cndo2021/ui/discussionboard" rel="noreferrer">
+        <Button style={{ color: '#037f8c' }}>DiscussionBoard</Button>
+      </Styled.MenuLink>
+      <Styled.MenuLink href="/cndo2021/timetables" rel="noreferrer">
         <Button style={{ color: '#037f8c' }}>Timetable</Button>
       </Styled.MenuLink>
       <Button href={url} style={{ color: '#037f8c' }}>

--- a/src/components/Menu/DesktopMenu.tsx
+++ b/src/components/Menu/DesktopMenu.tsx
@@ -1,6 +1,7 @@
 import React from 'react'
 import Button from '@material-ui/core/Button'
 import * as Styled from './styled'
+import * as CommonStyled from '../../styles/styled'
 
 type Props = {
   url: string
@@ -9,15 +10,15 @@ type Props = {
 export const DesktopMenu: React.FC<Props> = ({ url }) => {
   return (
     <Styled.DesktopMenu>
-      <Styled.MenuLink href="/cndo2021/ui#booths" rel="noreferrer">
+      <CommonStyled.MenuLink href="/cndo2021/ui#booths" rel="noreferrer">
         <Button style={{ color: '#037f8c' }}>Booths</Button>
-      </Styled.MenuLink>
-      <Styled.MenuLink href="/cndo2021/ui/discussionboard" rel="noreferrer">
+      </CommonStyled.MenuLink>
+      <CommonStyled.MenuLink href="/cndo2021/ui/discussionboard" rel="noreferrer">
         <Button style={{ color: '#037f8c' }}>DiscussionBoard</Button>
-      </Styled.MenuLink>
-      <Styled.MenuLink href="/cndo2021/timetables" rel="noreferrer">
+      </CommonStyled.MenuLink>
+      <CommonStyled.MenuLink href="/cndo2021/timetables" rel="noreferrer">
         <Button style={{ color: '#037f8c' }}>Timetable</Button>
-      </Styled.MenuLink>
+      </CommonStyled.MenuLink>
       <Button href={url} style={{ color: '#037f8c' }}>
         Logout
       </Button>

--- a/src/components/Menu/MobileMenu.tsx
+++ b/src/components/Menu/MobileMenu.tsx
@@ -1,6 +1,7 @@
 import React from 'react'
 import Button from '@material-ui/core/Button'
 import * as Styled from './styled'
+import * as CommonStyled from '../../styles/styled'
 
 type Props = {
   url: string
@@ -9,15 +10,15 @@ type Props = {
 export const MobileMenu: React.FC<Props> = ({ url }) => {
   return (
     <Styled.MobileMenu>
-      <Styled.MenuLink href="/cndo2021/ui#booths" rel="noreferrer">
+      <CommonStyled.MenuLink href="/cndo2021/ui#booths" rel="noreferrer">
         <Button style={{ color: '#037f8c' }}>Booths</Button>
-      </Styled.MenuLink>
-      <Styled.MenuLink href="/cndo2021/ui/discussionboard" rel="noreferrer">
+      </CommonStyled.MenuLink>
+      <CommonStyled.MenuLink href="/cndo2021/ui/discussionboard" rel="noreferrer">
         <Button style={{ color: '#037f8c' }}>Discussion</Button>
-      </Styled.MenuLink>
-      <Styled.MenuLink href="/cndo2021/timetables" rel="noreferrer">
+      </CommonStyled.MenuLink>
+      <CommonStyled.MenuLink href="/cndo2021/timetables" rel="noreferrer">
         <Button style={{ color: '#037f8c' }}>Timetable</Button>
-      </Styled.MenuLink>
+      </CommonStyled.MenuLink>
       <Button href={url} style={{ color: '#037f8c' }}>
         Logout
       </Button>

--- a/src/components/Menu/MobileMenu.tsx
+++ b/src/components/Menu/MobileMenu.tsx
@@ -13,6 +13,13 @@ export const MobileMenu: React.FC<Props> = ({ url }) => {
         <Button style={{ color: '#037f8c' }}>Booths</Button>
       </Styled.MenuLink>
       <Styled.MenuLink
+        href="/cndo2021/ui/discussionboard"
+        target="_blank"
+        rel="noreferrer"
+      >
+        <Button style={{ color: '#037f8c' }}>DiscussionBoard</Button>
+      </Styled.MenuLink>
+      <Styled.MenuLink
         href="/cndo2021/timetables"
         target="_blank"
         rel="noreferrer"

--- a/src/components/Menu/MobileMenu.tsx
+++ b/src/components/Menu/MobileMenu.tsx
@@ -12,18 +12,10 @@ export const MobileMenu: React.FC<Props> = ({ url }) => {
       <Styled.MenuLink href="/cndo2021/ui#booths" rel="noreferrer">
         <Button style={{ color: '#037f8c' }}>Booths</Button>
       </Styled.MenuLink>
-      <Styled.MenuLink
-        href="/cndo2021/ui/discussionboard"
-        target="_blank"
-        rel="noreferrer"
-      >
+      <Styled.MenuLink href="/cndo2021/ui/discussionboard" rel="noreferrer">
         <Button style={{ color: '#037f8c' }}>Discussion</Button>
       </Styled.MenuLink>
-      <Styled.MenuLink
-        href="/cndo2021/timetables"
-        target="_blank"
-        rel="noreferrer"
-      >
+      <Styled.MenuLink href="/cndo2021/timetables" rel="noreferrer">
         <Button style={{ color: '#037f8c' }}>Timetable</Button>
       </Styled.MenuLink>
       <Button href={url} style={{ color: '#037f8c' }}>

--- a/src/components/Menu/MobileMenu.tsx
+++ b/src/components/Menu/MobileMenu.tsx
@@ -17,7 +17,7 @@ export const MobileMenu: React.FC<Props> = ({ url }) => {
         target="_blank"
         rel="noreferrer"
       >
-        <Button style={{ color: '#037f8c' }}>DiscussionBoard</Button>
+        <Button style={{ color: '#037f8c' }}>Discussion</Button>
       </Styled.MenuLink>
       <Styled.MenuLink
         href="/cndo2021/timetables"

--- a/src/components/Menu/styled.ts
+++ b/src/components/Menu/styled.ts
@@ -43,10 +43,6 @@ export const FooterLink = styled.a`
   color: gray;
 `
 
-export const MenuLink = styled.a`
-  text-decoration-line: none;
-`
-
 export const DesktopMenu = styled.div`
   display: none;
   justify-content: flex-end;

--- a/src/components/Miro/Miro.tsx
+++ b/src/components/Miro/Miro.tsx
@@ -1,0 +1,35 @@
+import React from 'react'
+import * as Styled from './styled'
+
+type Props = {
+  miroId: string
+  liveEmbed?: boolean
+  viewport?: string
+}
+
+export const Miro: React.FC<Props> = ({ miroId, liveEmbed, viewport }) => {
+  const embedMode = () => {
+    return liveEmbed ? 'live-embed' : 'embed'
+  }
+
+  const getViewport = () => {
+    return viewport !== undefined ? viewport + '&' : ''
+  }
+
+  const miroSrc = (miroId: string) => {
+    return `https://miro.com/app/${embedMode()}/${miroId}/?${getViewport()}autoplay=yep`
+  }
+
+  return (
+    <Styled.MiroContainer>
+      <Styled.MiroIframe
+        width="800"
+        height="600"
+        src={miroSrc(miroId)}
+        frameBorder="0"
+        scrolling="no"
+        allowFullScreen
+      />
+    </Styled.MiroContainer>
+  )
+}

--- a/src/components/Miro/index.tsx
+++ b/src/components/Miro/index.tsx
@@ -1,0 +1,1 @@
+export { Miro } from './Miro'

--- a/src/components/Miro/styled.ts
+++ b/src/components/Miro/styled.ts
@@ -1,0 +1,16 @@
+import styled from 'styled-components'
+
+export const MiroContainer = styled.div`
+  position: relative;
+  width: 100%;
+  height: 0;
+  padding-top: 60%;
+`
+
+export const MiroIframe = styled.iframe`
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+`

--- a/src/components/Player/Player.tsx
+++ b/src/components/Player/Player.tsx
@@ -1,5 +1,6 @@
 import React from 'react'
 import * as Styled from './styled'
+import * as CommonStyled from '../../styles/styled'
 
 type Props = {
   vimeoId?: string
@@ -8,15 +9,19 @@ type Props = {
 
 export const Player: React.FC<Props> = ({ vimeoId, autoplay }) => {
   return (
-    <Styled.Container
-      src={`https://player.vimeo.com/video/${vimeoId}?autoplay=${Number(
-        autoplay,
-      )}`}
-      frameBorder="0"
-      allow="autoplay; fullscreen"
-      //webkitallowfullscreen
-      //mozallowfullscreen
-      allowFullScreen
-    />
+    <CommonStyled.Container>
+      <Styled.PlayerContainer>
+        <Styled.PlayerIframe
+        src={`https://player.vimeo.com/video/${vimeoId}?autoplay=${Number(
+          autoplay,
+        )}`}
+        frameBorder="0"
+        allow="autoplay; fullscreen"
+        //webkitallowfullscreen
+        //mozallowfullscreen
+        allowFullScreen
+      />
+      </Styled.PlayerContainer>
+    </CommonStyled.Container>
   )
 }

--- a/src/components/Player/__tests__/__snapshots__/Player.spec.tsx.snap
+++ b/src/components/Player/__tests__/__snapshots__/Player.spec.tsx.snap
@@ -1,11 +1,19 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Player 1`] = `
-<iframe
-  allow="autoplay; fullscreen"
-  allowFullScreen={true}
-  className="sc-bdfBwQ fJeVmG"
-  frameBorder="0"
-  src="https://player.vimeo.com/video/453943528?autoplay=1"
-/>
+<div
+  className="sc-dlfnbm fbDFAt"
+>
+  <div
+    className="sc-bdfBwQ etvdGK"
+  >
+    <iframe
+      allow="autoplay; fullscreen"
+      allowFullScreen={true}
+      className="sc-gsTCUz kUeSWu"
+      frameBorder="0"
+      src="https://player.vimeo.com/video/453943528?autoplay=1"
+    />
+  </div>
+</div>
 `;

--- a/src/components/Player/styled.ts
+++ b/src/components/Player/styled.ts
@@ -1,6 +1,17 @@
 import styled from 'styled-components'
 
-export const Container = styled.iframe`
+export const PlayerContainer = styled.div`
+position: relative;
+width: 100%;
+height: 0;
+padding-top: 60%;
+`
+
+
+export const PlayerIframe = styled.iframe`
+  position: absolute;
+  top: 0;
+  left: 0;
   width: 100%;
-  height: 500px;
+  height: 100%;
 `

--- a/src/components/Sponsors/Sponsors.tsx
+++ b/src/components/Sponsors/Sponsors.tsx
@@ -1,6 +1,7 @@
 import React, { useState, useEffect } from 'react'
 import { SponsorApi, Sponsor, Configuration } from '../../client-axios'
 import * as Styled from './styled'
+import * as CommonStyled from '../../styles/styled'
 
 export const Sponsors: React.FC = () => {
   const settings = {
@@ -46,8 +47,7 @@ export const Sponsors: React.FC = () => {
   }, [])
 
   return (
-    <Styled.Outer>
-      <Styled.Container>
+      <CommonStyled.Container>
         <Styled.CNDOSlider {...settings}>
           {data.map((sponsor) => (
             <Styled.Sponsor key={sponsor.id}>
@@ -57,7 +57,6 @@ export const Sponsors: React.FC = () => {
             </Styled.Sponsor>
           ))}
         </Styled.CNDOSlider>
-      </Styled.Container>
-    </Styled.Outer>
+      </CommonStyled.Container>
   )
 }

--- a/src/components/Sponsors/styled.ts
+++ b/src/components/Sponsors/styled.ts
@@ -5,15 +5,6 @@ import 'slick-carousel/slick/slick-theme.css'
 
 export const CNDOSlider = styled(Slider)``
 
-export const Outer = styled.div`
-  padding: 15px 0 0 0;
-`
-
-export const Container = styled.div`
-  background: rgba(255, 255, 255, 0.6);
-  padding: 10px 0px 5px 0px;
-`
-
 export const Sponsor = styled.div`
   position: relative;
   height: 40px;

--- a/src/components/TalkSelector/TalkSelector.tsx
+++ b/src/components/TalkSelector/TalkSelector.tsx
@@ -58,7 +58,11 @@ export const TalkSelector: React.FC<Props> = ({
                 selected={talk.id === selectedTalk?.id}
                 onClick={() => selectTalk(talk)}
               >
-                <Styled.Text>{talk.title}</Styled.Text>
+                <Styled.Text>
+                  {talk.onAir && <Styled.Live>LIVE</Styled.Live>} {dayjs(talk.startTime).format('HH:mm')}-{dayjs(talk.endTime).format('HH:mm')}
+                  <br />
+                  {talk.title}
+                </Styled.Text>
               </Styled.Item>
             )
           }

--- a/src/components/TalkSelector/__tests__/__snapshots__/TalkSelector.spec.tsx.snap
+++ b/src/components/TalkSelector/__tests__/__snapshots__/TalkSelector.spec.tsx.snap
@@ -2,15 +2,15 @@
 
 exports[`TalkSelector 1`] = `
 <div
-  className="sc-bdfBwQ cKbKdI"
+  className="sc-bdfBwQ fZOdB"
 >
   <div
-    className="sc-gsTCUz hhRAir"
+    className="sc-gsTCUz gsmcqU"
   >
     このトラックのセッション
   </div>
   <ul
-    className="MuiList-root sc-dlfnbm kskwDK MuiList-padding"
+    className="MuiList-root sc-dlfnbm dRyweE MuiList-padding"
   />
 </div>
 `;

--- a/src/components/TalkSelector/styled.ts
+++ b/src/components/TalkSelector/styled.ts
@@ -2,8 +2,8 @@ import styled from 'styled-components'
 import { List as OriginList, ListItem } from '@material-ui/core'
 
 export const Container = styled.div`
-  padding: 0 8px 10px 8px;
   height: 450px;
+  padding-right: 5px;
 `
 
 export const Title = styled.div`
@@ -11,7 +11,6 @@ export const Title = styled.div`
   font-weight: bold;
   text-align: center;
   padding: 10px;
-  border: 1.5px solid black;
   border-bottom: none;
   border-radius: 10px 10px 0px 0px;
   background-color: #ffffff;
@@ -20,7 +19,7 @@ export const Title = styled.div`
 
 export const List = styled(OriginList)`
   height: 405px;
-  border: 1.5px solid;
+  border-top: 1px solid #888;
   overflow-y: scroll;
   border-radius: 0px 0px 10px 10px;
   background-color: #ffffff;
@@ -49,4 +48,11 @@ export const Text = styled.div`
   font-size: 0.9rem;
   line-height: 1.2rem;
   padding: 2px 0;
+`
+export const Live = styled.span`
+  font-weight: bold;
+  background-color: red;
+  padding: 2px;
+  color: white;
+  border-radius: 3px;
 `

--- a/src/components/Track/Track.tsx
+++ b/src/components/Track/Track.tsx
@@ -99,21 +99,21 @@ export const TrackView: React.FC<Props> = ({ selectedTrack, propTalks }) => {
   }, [selectedTrack, selectedTalk])
 
   return (
-    <Grid container spacing={1} justify="center" alignItems="flex-start">
+    <Grid container spacing={0} justify="center" alignItems="flex-start">
       <Grid item xs={12} md={8}>
         <Player vimeoId={videoId} autoplay={true}></Player>
         <Sponsors />
       </Grid>
-      <Grid item xs={12} md={3}>
+      <Grid item xs={12} md={4}>
         <Chat talk={selectedTalk} />
       </Grid>
-      <Grid item xs={12} md={8}>
+      <Grid item xs={12} md={8} alignItems="stretch" style={{height: '100%'}}>
         <TalkInfo
           selectedTalk={selectedTalk}
           selectedTrackName={selectedTrack?.name}
         />
       </Grid>
-      <Grid item xs={12} md={3}>
+      <Grid item xs={12} md={4} alignItems="stretch" style={{height: '100%'}}>
         <TalkSelector
           selectedTalk={selectedTalk}
           selectedTrackId={selectedTrack?.id}
@@ -121,7 +121,7 @@ export const TrackView: React.FC<Props> = ({ selectedTrack, propTalks }) => {
           selectTalk={selectTalk}
         />
       </Grid>
-      <Grid item xs={12} md={11}>
+      <Grid item xs={12} md={12}>
         <Booths openNewWindow={true} />
       </Grid>
     </Grid>

--- a/src/pages/discussionboard.tsx
+++ b/src/pages/discussionboard.tsx
@@ -1,20 +1,39 @@
 import { Layout } from '../components/Layout'
 import { Miro } from '../components/Miro'
-import { Grid } from '@material-ui/core'
+import { Button, Grid } from '@material-ui/core'
+import * as CommonStyled from '../styles/styled'
 
 const DiscussionPage: React.FC = () => {
   return (
     <Layout title="CloudNative Days 2021 - DiscussionBoard">
-      <Grid container spacing={1} justify="center" alignItems="flex-start">
-        <Grid item xs={12} md={8}>
-          <h2>DiscussionBoard</h2>
-          <Miro
-            miroId="o9J_leFyDWo="
-            liveEmbed={false}
-            viewport="moveToViewport=-94,-1521,7088,5264"
-          />
+      <CommonStyled.OuterContainer
+        container
+        spacing={1}
+        justify="center"
+        alignItems="flex-start"
+      >
+        <Grid item xs={12} md={12}>
+          <CommonStyled.Container>
+            <CommonStyled.Header2 centerized={true}>
+              DiscussionBoard
+            </CommonStyled.Header2>
+            <CommonStyled.CenterizedContainer>
+              <Button
+                variant="contained"
+                color="secondary"
+                href="https://miro.com/app/board/o9J_lRiwMdw=/"
+              >
+                参加する
+              </Button>
+            </CommonStyled.CenterizedContainer>
+            <Miro
+              miroId="o9J_lRiwMdw="
+              liveEmbed={false}
+              viewport="moveToViewport=347,-121,3506,3506"
+            />
+          </CommonStyled.Container>
         </Grid>
-      </Grid>
+      </CommonStyled.OuterContainer>
     </Layout>
   )
 }

--- a/src/pages/discussionboard.tsx
+++ b/src/pages/discussionboard.tsx
@@ -1,0 +1,22 @@
+import { Layout } from '../components/Layout'
+import { Miro } from '../components/Miro'
+import { Grid } from '@material-ui/core'
+
+const DiscussionPage: React.FC = () => {
+  return (
+    <Layout title="CloudNative Days 2021 - DiscussionBoard">
+      <Grid container spacing={1} justify="center" alignItems="flex-start">
+        <Grid item xs={12} md={8}>
+          <h2>DiscussionBoard</h2>
+          <Miro
+            miroId="o9J_leFyDWo="
+            liveEmbed={false}
+            viewport="moveToViewport=-94,-1521,7088,5264"
+          />
+        </Grid>
+      </Grid>
+    </Layout>
+  )
+}
+
+export default DiscussionPage

--- a/src/styles/styled.ts
+++ b/src/styles/styled.ts
@@ -32,3 +32,7 @@ export const MiroIframe = styled.iframe`
   width: 100%;
   min-height: 500px;
 `
+
+export const MenuLink = styled.a`
+  text-decoration-line: none;
+`

--- a/src/styles/styled.ts
+++ b/src/styles/styled.ts
@@ -1,0 +1,34 @@
+import styled from 'styled-components'
+import { Grid } from '@material-ui/core'
+
+export const Container = styled.div`
+  height: 100%;
+  background: rgba(255, 255, 255, 0.7);
+  font-size: 1.2em;
+  border-radius: 10px;
+  margin: 5px;
+  padding: 10px;
+`
+
+export const OuterContainer = styled(Grid)`
+  height: 100%;
+`
+
+export const CenterizedContainer = styled.div`
+  text-align: center;
+`
+
+export const Header2 = styled.h2<{ centerized?: boolean }>`
+  color: #037f8c;
+  ${({ centerized }) => (centerized ? 'text-align: center' : '')};
+`
+
+export const Header3 = styled.h3<{ centerized?: boolean }>`
+  color: #037f8c;
+  ${({ centerized }) => (centerized ? 'text-align: center' : '')};
+`
+
+export const MiroIframe = styled.iframe`
+  width: 100%;
+  min-height: 500px;
+`


### PR DESCRIPTION
見た目で気になったところをまとめて修正
- グリッドは原則角丸でそろえる
- paddingやmarginでそろっていなかったところをそろえた
- 配信画面は画面いっぱいに領域を使うように(12 Grid フル)
- 共通化できるところは共通化
- 動画のiframeを画面サイズに応じてフレキシブルに(これによりスマホでも余白が出なくなった)
- ライブ配信中のものには、トーク一覧で LIVE と表示されるように

※注 #106 のPRに続く形でコミットを積んでいるので、そちらを先にレビューお願いします

Fix #70 