### PR TITLE
talkを利用可能か判別するメソッドを追加

### DIFF
--- a/src/components/TalkSelector/TalkSelector.tsx
+++ b/src/components/TalkSelector/TalkSelector.tsx
@@ -14,6 +14,16 @@ interface TalkWithAvailable extends Talk {
   available: boolean
 }
 
+const isAvailable = (
+  now: number,
+  startTime: string,
+  conferanceDayDate?: string,
+) => {
+  if (!conferanceDayDate) return true
+  const startDate = `${conferanceDayDate} ${dayjs(startTime).format('HH:mm')}`
+  return now - dayjs(startDate).unix() >= 0
+}
+
 export const TalkSelector: React.FC<Props> = ({
   selectedTrackId,
   selectedTalk,
@@ -39,7 +49,10 @@ export const TalkSelector: React.FC<Props> = ({
   useEffect(() => {
     setTalksWithAvailableState(
       talks.map((talk) => {
-        return { ...talk, available: now - dayjs(talk.startTime).unix() >= 0 }
+        return {
+          ...talk,
+          available: isAvailable(now, talk.startTime, talk.conferenceDayDate),
+        }
       }),
     )
   }, [talks, now])
@@ -59,7 +72,9 @@ export const TalkSelector: React.FC<Props> = ({
                 onClick={() => selectTalk(talk)}
               >
                 <Styled.Text>
-                  {talk.onAir && <Styled.Live>LIVE</Styled.Live>} {dayjs(talk.startTime).format('HH:mm')}-{dayjs(talk.endTime).format('HH:mm')}
+                  {talk.onAir && <Styled.Live>LIVE</Styled.Live>}{' '}
+                  {dayjs(talk.startTime).format('HH:mm')}-
+                  {dayjs(talk.endTime).format('HH:mm')}
                   <br />
                   {talk.title}
                 </Styled.Text>

--- a/src/components/Track/Track.tsx
+++ b/src/components/Track/Track.tsx
@@ -107,13 +107,13 @@ export const TrackView: React.FC<Props> = ({ selectedTrack, propTalks }) => {
       <Grid item xs={12} md={4}>
         <Chat talk={selectedTalk} />
       </Grid>
-      <Grid item xs={12} md={8} alignItems="stretch" style={{height: '100%'}}>
+      <Grid item xs={12} md={8} style={{ height: '100%' }}>
         <TalkInfo
           selectedTalk={selectedTalk}
           selectedTrackName={selectedTrack?.name}
         />
       </Grid>
-      <Grid item xs={12} md={4} alignItems="stretch" style={{height: '100%'}}>
+      <Grid item xs={12} md={4} alignItems="stretch" style={{ height: '100%' }}>
         <TalkSelector
           selectedTalk={selectedTalk}
           selectedTrackId={selectedTrack?.id}


### PR DESCRIPTION
ref #107
* `startTime` と `conferanceDayDate` からセッションの開始時間を計算するメソッドを追加
*  `conferanceDayDate` が未設定の場合はセッションを閲覧不可能にはしない
* 開発が大変になってしまうので、リリースはイベント直前にしておく
