### PR TITLE
ブース説明などのaタグや改行を反映させる

### DIFF
--- a/src/components/BoothPage/BoothPage.tsx
+++ b/src/components/BoothPage/BoothPage.tsx
@@ -83,10 +83,6 @@ export const BoothPage: React.FC<Props> = ({ boothId }) => {
     getBooth()
   }, [boothId])
 
-  useEffect(() => {
-    console.log(booth)
-  }, [booth])
-
   function createMarkup(text?: string) {
     if (!text) return
     return { __html: text }

--- a/src/components/BoothPage/BoothPage.tsx
+++ b/src/components/BoothPage/BoothPage.tsx
@@ -83,6 +83,15 @@ export const BoothPage: React.FC<Props> = ({ boothId }) => {
     getBooth()
   }, [boothId])
 
+  useEffect(() => {
+    console.log(booth)
+  }, [booth])
+
+  function createMarkup(text?: string) {
+    if (!text) return
+    return { __html: text }
+  }
+
   return (
     <CommonStyled.OuterContainer
       container
@@ -99,13 +108,17 @@ export const BoothPage: React.FC<Props> = ({ boothId }) => {
             <CommonStyled.Header2 centerized={true}>
               {booth?.sponsorName}
             </CommonStyled.Header2>
-            <p>{booth?.description}</p>
+            <Styled.PreWrapP
+              dangerouslySetInnerHTML={createMarkup(booth?.description)}
+            ></Styled.PreWrapP>
           </Grid>
 
           <AttachmentImages images={booth?.keyImageUrls} />
           <Grid item xs={12}>
             <CommonStyled.CenterizedContainer>
-              <p>{booth?.text}</p>
+              <Styled.PreWrapP
+                dangerouslySetInnerHTML={createMarkup(booth?.text)}
+              ></Styled.PreWrapP>
             </CommonStyled.CenterizedContainer>
           </Grid>
 

--- a/src/components/BoothPage/styled.ts
+++ b/src/components/BoothPage/styled.ts
@@ -34,3 +34,7 @@ export const KeyImage = styled.img`
 export const PdfContainer = styled.div`
   text-align: center;
 `
+
+export const PreWrapP = styled.p`
+  white-space: pre-wrap;
+`


### PR DESCRIPTION
fix https://github.com/cloudnativedaysjp/dreamkast-ui/issues/123

dangerouslySetInnerHTMLをつかっているが、APIが返してくるテキストはadmin画面内で設定したもので制御可能なので問題ないだろうと思う
長期的にはAPIにはhtmlを返させないようにしたいが。

https://ja.reactjs.org/docs/dom-elements.html


