### PR TITLE
チャットメッセージの時刻表示が間違っていた

### DIFF
--- a/src/components/Chat/internal/ChatBox/internal/ChatMessage/ChatMessage.tsx
+++ b/src/components/Chat/internal/ChatBox/internal/ChatMessage/ChatMessage.tsx
@@ -89,7 +89,7 @@ export const ChatMessage: React.FC<Props> = ({
       <Styled.ChatMessage isChat={isChat} isSelected={selected}>
         <Grid container>
           <Grid item xs={11}>
-            {dayjs(chatMessage?.createdAt).tz('Asia/Tokyo').format('HH:MM')}
+            {dayjs(chatMessage?.createdAt).tz('Asia/Tokyo').format('HH:mm')}
           </Grid>
 
           <Grid item xs={1}>


### PR DESCRIPTION
- MM: 月
- mm: 分

fix https://github.com/cloudnativedaysjp/dreamkast-ui/issues/121