### PR TITLE
TalkSelectorについて3点修正

### DIFF
--- a/schemas/swagger.yml
+++ b/schemas/swagger.yml
@@ -332,6 +332,15 @@ components:
           type: string
         coc:
           type: string
+        conferenceDays:
+          type: array
+          items:
+            type: object
+            properties:
+              id:
+                type: number
+              date:
+                type: string
       example:
         id: 2
         name: "CloudNative Days Spring 2020 ONLINE"

--- a/src/client-axios/api.ts
+++ b/src/client-axios/api.ts
@@ -333,6 +333,31 @@ export interface Event {
      * @memberof Event
      */
     coc: string;
+    /**
+     * 
+     * @type {Array<EventConferenceDays>}
+     * @memberof Event
+     */
+    conferenceDays?: Array<EventConferenceDays>;
+}
+/**
+ * 
+ * @export
+ * @interface EventConferenceDays
+ */
+export interface EventConferenceDays {
+    /**
+     * 
+     * @type {number}
+     * @memberof EventConferenceDays
+     */
+    id?: number;
+    /**
+     * 
+     * @type {string}
+     * @memberof EventConferenceDays
+     */
+    date?: string;
 }
 /**
  * 
@@ -1149,7 +1174,9 @@ export class EventApi extends BaseAPI {
      * @memberof EventApi
      */
     public apiV1EventsEventAbbrGet(eventAbbr: string, options?: any) {
-        return EventApiFp(this.configuration).apiV1EventsEventAbbrGet(eventAbbr, options).then((request) => request(this.axios, this.basePath));
+        return EventApiFp(this.configuration).apiV1EventsEventAbbrGet(eventAbbr, options).then((request) => {
+            return request(this.axios, this.basePath)
+        });
     }
 }
 

--- a/src/components/TalkSelector/TalkSelector.tsx
+++ b/src/components/TalkSelector/TalkSelector.tsx
@@ -38,11 +38,25 @@ export const TalkSelector: React.FC<Props> = ({
 
   useEffect(() => {
     setTalksWithAvailableState(
-      talks.map((talk) => {
+      sortTalks(talks).map((talk) => {
         return { ...talk, available: now - dayjs(talk.startTime).unix() >= 0 }
       }),
     )
   }, [talks, now])
+
+  const sortTalks = (talks: Talk[]): Talk[] => {
+    return talks.sort((n1, n2) => {
+      if (n1.startTime > n2.startTime) {
+        return 1
+      }
+
+      if (n1.startTime < n2.startTime) {
+        return -1
+      }
+
+      return 0
+    })
+  }
 
   return (
     <Styled.Container>

--- a/src/components/TalkSelector/TalkSelector.tsx
+++ b/src/components/TalkSelector/TalkSelector.tsx
@@ -37,8 +37,11 @@ export const TalkSelector: React.FC<Props> = ({
   }, [])
 
   useEffect(() => {
+    const filteredTalks = sortTalks(talks).filter((talk) => {
+      return talk.showOnTimetable
+    })
     setTalksWithAvailableState(
-      sortTalks(talks).map((talk) => {
+      filteredTalks.map((talk) => {
         return { ...talk, available: now - dayjs(talk.startTime).unix() >= 0 }
       }),
     )

--- a/src/components/Track/Track.tsx
+++ b/src/components/Track/Track.tsx
@@ -8,20 +8,25 @@ import {
   TalkApi,
   Configuration,
   Profile,
+  Event,
 } from '../../client-axios'
 import { TalkSelector } from '../TalkSelector'
 import { TalkInfo } from '../TalkInfo'
 import { Sponsors } from '../Sponsors'
 import { Booths } from '../Booths'
 import ActionCable from 'actioncable'
+import dayjs from 'dayjs'
+import 'dayjs/locale/ja'
 
 type Props = {
+  event?: Event
   profile?: Profile
   selectedTrack?: Track
   propTalks?: Talk[]
 }
 
 export const TrackView: React.FC<Props> = ({
+  event,
   profile,
   selectedTrack,
   propTalks,
@@ -31,6 +36,17 @@ export const TrackView: React.FC<Props> = ({
   const [selectedTalk, setSelectedTalk] = useState<Talk>()
   const [timer, setTimer] = useState<number>()
 
+  const findDayId = () => {
+    const today = dayjs(new Date()).tz('Asia/Tokyo').format('YYYY-MM-DD')
+    let dayId = ''
+    event?.conferenceDays?.forEach((day) => {
+      if (day.date == today && day.id) {
+        dayId = String(day.id)
+      }
+    })
+    return dayId
+  }
+
   const getTalks = useCallback(async () => {
     const api = new TalkApi(
       new Configuration({ basePath: window.location.origin }),
@@ -38,7 +54,7 @@ export const TrackView: React.FC<Props> = ({
     const { data } = await api.apiV1TalksGet(
       'cndo2021',
       String(selectedTrack?.id),
-      '6,7',
+      findDayId(),
     )
     setTalks(data)
   }, [selectedTrack])
@@ -118,13 +134,13 @@ export const TrackView: React.FC<Props> = ({
       <Grid item xs={12} md={4}>
         <Chat profile={profile} talk={selectedTalk} />
       </Grid>
-      <Grid item xs={12} md={8} alignItems="stretch" style={{height: '100%'}}>
+      <Grid item xs={12} md={8} alignItems="stretch" style={{ height: '100%' }}>
         <TalkInfo
           selectedTalk={selectedTalk}
           selectedTrackName={selectedTrack?.name}
         />
       </Grid>
-      <Grid item xs={12} md={4} alignItems="stretch" style={{height: '100%'}}>
+      <Grid item xs={12} md={4} alignItems="stretch" style={{ height: '100%' }}>
         <TalkSelector
           selectedTalk={selectedTalk}
           selectedTrackId={selectedTrack?.id}

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -8,6 +8,8 @@ import {
   Configuration,
   ProfileApi,
   Profile,
+  Event,
+  EventApi,
 } from '../client-axios'
 
 const IndexPage: React.FC = () => {
@@ -15,11 +17,20 @@ const IndexPage: React.FC = () => {
   const [selectedTrack, setSelectedTrack] = useState<Track>()
   const [tracks, setTracks] = useState<Track[]>([])
   const [profile, setProfile] = useState<Profile>()
+  const [event, setEvent] = useState<Event>()
 
   // Handlers
   const selectTrack = (selectedTrack: Track) => {
     setSelectedTrack(selectedTrack)
   }
+
+  const getEvent = useCallback(async () => {
+    const eventApi = new EventApi(
+      new Configuration({ basePath: window.location.origin }),
+    )
+    const { data } = await eventApi.apiV1EventsEventAbbrGet('cndo2021')
+    setEvent(data)
+  }, [])
 
   const getProfile = useCallback(async () => {
     const api = new ProfileApi(
@@ -40,6 +51,7 @@ const IndexPage: React.FC = () => {
   }, [])
 
   useEffect(() => {
+    getEvent()
     getProfile()
     getTracks()
   }, [])
@@ -51,7 +63,11 @@ const IndexPage: React.FC = () => {
         selectedTrack={selectedTrack}
         selectTrack={selectTrack}
       />
-      <TrackView profile={profile} selectedTrack={selectedTrack} />
+      <TrackView
+        event={event}
+        profile={profile}
+        selectedTrack={selectedTrack}
+      />
     </Layout>
   )
 }


### PR DESCRIPTION
- TalkSelectorにDay1/Day2両方のセッションが表示されていた問題の修正
  - ConferenceDays情報をAPIから取得し、その日のセッションだけをGETするように変更
- TalkSelectorに表示されているセッション一覧が開始時刻順になっていない問題を修正
- TalkSelector上にCM用のセッションが表示されてしまっている問題を修正
  - show_on_timetable=trueのセッションのみ表示する

fix https://github.com/cloudnativedaysjp/dreamkast-ui/issues/119
fix https://github.com/cloudnativedaysjp/dreamkast-ui/issues/120