### PR TITLE
Remove booth link

### DIFF
--- a/src/components/Layout/__tests__/__snapshots__/Layout.spec.tsx.snap
+++ b/src/components/Layout/__tests__/__snapshots__/Layout.spec.tsx.snap
@@ -25,40 +25,6 @@ exports[`Layout 1`] = `
         >
           <a
             className="sc-kfzAmx dLIGSx"
-            href="/cicd2021/ui#booths"
-            rel="noreferrer"
-          >
-            <button
-              className="MuiButtonBase-root MuiButton-root MuiButton-text"
-              disabled={false}
-              onBlur={[Function]}
-              onDragLeave={[Function]}
-              onFocus={[Function]}
-              onKeyDown={[Function]}
-              onKeyUp={[Function]}
-              onMouseDown={[Function]}
-              onMouseLeave={[Function]}
-              onMouseUp={[Function]}
-              onTouchEnd={[Function]}
-              onTouchMove={[Function]}
-              onTouchStart={[Function]}
-              style={
-                Object {
-                  "color": "#423A57",
-                }
-              }
-              tabIndex={0}
-              type="button"
-            >
-              <span
-                className="MuiButton-label"
-              >
-                Booths
-              </span>
-            </button>
-          </a>
-          <a
-            className="sc-kfzAmx dLIGSx"
             href="/cicd2021/ui/discussionboard"
             rel="noreferrer"
           >
@@ -159,40 +125,6 @@ exports[`Layout 1`] = `
       <div
         className="sc-fodVxV gJEXNK"
       >
-        <a
-          className="sc-kfzAmx dLIGSx"
-          href="/cicd2021/ui#booths"
-          rel="noreferrer"
-        >
-          <button
-            className="MuiButtonBase-root MuiButton-root MuiButton-text"
-            disabled={false}
-            onBlur={[Function]}
-            onDragLeave={[Function]}
-            onFocus={[Function]}
-            onKeyDown={[Function]}
-            onKeyUp={[Function]}
-            onMouseDown={[Function]}
-            onMouseLeave={[Function]}
-            onMouseUp={[Function]}
-            onTouchEnd={[Function]}
-            onTouchMove={[Function]}
-            onTouchStart={[Function]}
-            style={
-              Object {
-                "color": "#423A57",
-              }
-            }
-            tabIndex={0}
-            type="button"
-          >
-            <span
-              className="MuiButton-label"
-            >
-              Booths
-            </span>
-          </button>
-        </a>
         <a
           className="sc-kfzAmx dLIGSx"
           href="/cicd2021/ui/discussionboard"

--- a/src/components/Menu/DesktopMenu.tsx
+++ b/src/components/Menu/DesktopMenu.tsx
@@ -10,9 +10,6 @@ type Props = {
 export const DesktopMenu: React.FC<Props> = ({ url }) => {
   return (
     <Styled.DesktopMenu>
-      <CommonStyled.MenuLink href="/cicd2021/ui#booths" rel="noreferrer">
-        <Button style={{ color: '#423A57' }}>Booths</Button>
-      </CommonStyled.MenuLink>
       <CommonStyled.MenuLink
         href="/cicd2021/ui/discussionboard"
         rel="noreferrer"

--- a/src/components/Menu/MobileMenu.tsx
+++ b/src/components/Menu/MobileMenu.tsx
@@ -10,9 +10,6 @@ type Props = {
 export const MobileMenu: React.FC<Props> = ({ url }) => {
   return (
     <Styled.MobileMenu>
-      <CommonStyled.MenuLink href="/cicd2021/ui#booths" rel="noreferrer">
-        <Button style={{ color: '#423A57' }}>Booths</Button>
-      </CommonStyled.MenuLink>
       <CommonStyled.MenuLink
         href="/cicd2021/ui/discussionboard"
         rel="noreferrer"

--- a/src/components/Track/Track.tsx
+++ b/src/components/Track/Track.tsx
@@ -13,7 +13,6 @@ import {
 import { TalkSelector } from '../TalkSelector'
 import { TalkInfo } from '../TalkInfo'
 import { Sponsors } from '../Sponsors'
-import { Booths } from '../Booths'
 import ActionCable from 'actioncable'
 //import dayjs from 'dayjs'
 import 'dayjs/locale/ja'
@@ -170,9 +169,6 @@ export const TrackView: React.FC<Props> = ({
           changeLiveMode={onChecked}
           selectTalk={selectTalk}
         />
-      </Grid>
-      <Grid item xs={12} md={12}>
-        <Booths openNewWindow={true} />
       </Grid>
     </Grid>
   )


### PR DESCRIPTION
Fix #163 

CI/CD ConferenceではBoothいらないのでリンクを削除
CNDT2021で復活する可能性はなくはないのでコンポーネントは消さずにいる
