### PR TITLE
video.jsとamazon-ivs-*のバージョンの組み合わせによってうまく動かないことがある？

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
         "react-slick": "^0.28.0",
         "slick-carousel": "^1.8.1",
         "use-interval": "^1.3.0",
-        "video.js": "^7.15.4"
+        "video.js": "^7.6.6"
     },
     "devDependencies": {
         "@types/actioncable": "^5.2.3",

--- a/src/components/IvsPlayer/IvsPlayer.tsx
+++ b/src/components/IvsPlayer/IvsPlayer.tsx
@@ -22,7 +22,7 @@ export const IvsPlayer: React.FC<Props> = ({ playBackUrl, autoplay }) => {
   useEffect(() => {
     const script = document.createElement('script')
     script.src =
-      'https://player.live-video.net/1.4.1/amazon-ivs-videojs-tech.min.js'
+      'https://player.live-video.net/1.2.0/amazon-ivs-videojs-tech.min.js'
     document.body.appendChild(script)
 
     script.addEventListener('load', () => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -7270,7 +7270,7 @@ verror@1.10.0:
     core-util-is "1.0.2"
     extsprintf "^1.2.0"
 
-"video.js@^6 || ^7", video.js@^7.15.4:
+"video.js@^6 || ^7", video.js@^7.6.6:
   version "7.15.4"
   resolved "https://registry.yarnpkg.com/video.js/-/video.js-7.15.4.tgz#0f96ef138035138cb30bf00a989b6174f0d16bac"
   integrity sha512-hghxkgptLUvfkpktB4wxcIVF3VpY/hVsMkrjHSv0jpj1bW9Jplzdt8IgpTm9YhlB1KYAp07syVQeZcBFUBwhkw==


### PR DESCRIPTION
手元だとなぜかこのバージョンの組み合わせ以外だと手元で再生されない。stagingは1.4.1と7.15.4で動いてるっぽいんですが。