### PR TITLE
未ログインでuiへ遷移したときはトップページへリダイレクトさせる

### DIFF
--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -36,8 +36,16 @@ const IndexPage: React.FC = () => {
     const api = new ProfileApi(
       new Configuration({ basePath: window.location.origin }),
     )
-    const { data } = await api.apiV1EventAbbrMyProfileGet('cndt2021')
-    setProfile(data)
+    const res = await api
+      .apiV1EventAbbrMyProfileGet('cndt2021')
+      .catch((error) => {
+        if (error.response && error.response.status === 403) {
+          const topUrl = window.location.href.replace('/ui', '')
+          window.location.href = topUrl
+        }
+      })
+    if (!res) return
+    setProfile(res.data)
   }, [])
 
   const getTracks = useCallback(async () => {


### PR DESCRIPTION
ref #157

未ログインの状態でuiへ遷移した場合には `my_profile` が403を返すので、その場合にはトップページへリダイレクトさせるようにする