### PR TITLE
Improve survey timing

### DIFF
--- a/src/components/Track/Track.tsx
+++ b/src/components/Track/Track.tsx
@@ -124,7 +124,8 @@ export const TrackView: React.FC<Props> = ({
             selectedTrack.id == msg[selectedTrack.id].trackId &&
             selectedTalk.id != msg[selectedTrack.id].id
           ) {
-            window.location.href = window.location.href.split('#')[0] + '#' + selectedTalk.id // Karteの仕様でページ内リンクを更新しないと同一PV扱いになりアンケートが出ない
+            window.location.href =
+              window.location.href.split('#')[0] + '#' + selectedTalk.id // Karteの仕様でページ内リンクを更新しないと同一PV扱いになりアンケートが出ない
             window.tracker.track('trigger_survey', {
               track_name: selectedTrack?.name,
               talk_id: selectedTalk?.id,

--- a/src/components/Track/Track.tsx
+++ b/src/components/Track/Track.tsx
@@ -124,13 +124,19 @@ export const TrackView: React.FC<Props> = ({
             selectedTrack.id == msg[selectedTrack.id].trackId &&
             selectedTalk.id != msg[selectedTrack.id].id
           ) {
+            window.location.href = window.location.href.split('#')[0] + '#' + selectedTalk.id // Karteの仕様でページ内リンクを更新しないと同一PV扱いになりアンケートが出ない
+            window.tracker.track('trigger_survey', {
+              track_name: selectedTrack?.name,
+              talk_id: selectedTalk?.id,
+              talk_name: selectedTalk?.title,
+            })
             setSelectedTalk(msg[selectedTrack.id])
             setVideoId(msg[selectedTrack.id].videoId)
           }
         },
       },
     )
-  }, [selectedTrack])
+  }, [selectedTrack, selectedTalk])
 
   useEffect(() => {
     clearInterval(timer)

--- a/src/components/TrackSelector/TrackSelector.tsx
+++ b/src/components/TrackSelector/TrackSelector.tsx
@@ -33,6 +33,7 @@ export const TrackSelector: React.FC<Props> = ({
       ) as Track
       setItem(selectedTrack.id)
       selectTrack(selectedTrack)
+      window.location.href = window.location.href.split('#')[0] + '#' + selectedTrack.name
     }
   }
   return (

--- a/src/components/TrackSelector/TrackSelector.tsx
+++ b/src/components/TrackSelector/TrackSelector.tsx
@@ -33,7 +33,8 @@ export const TrackSelector: React.FC<Props> = ({
       ) as Track
       setItem(selectedTrack.id)
       selectTrack(selectedTrack)
-      window.location.href = window.location.href.split('#')[0] + '#' + selectedTrack.name
+      window.location.href =
+        window.location.href.split('#')[0] + '#' + selectedTrack.name
     }
   }
   return (


### PR DESCRIPTION
Fix https://github.com/cloudnativedaysjp/dreamkast/issues/1198

今まではKarteのタイミングでアンケートを表示していたので、セッション視聴途中にアンケートが出ることがある苦情があった。

なのでWebSocketでセッション切り替えを受け取ったタイミングで、切り替え前のセッションに関するアンケートをトリガーするようにした