### PR TITLE
Update some configs for CI 

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,11 @@
+changelog:
+  exclude:
+    authors:
+      - "dreamkast-cloudnativedays"
+  categories:
+    - title: ♻ Update dependencies
+      labels:
+        - "dependencies"
+    - title: 💫 Other Changes
+      labels:
+        - "*"

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -7,7 +7,8 @@
   "packageRules": [
     {
       "matchManagers": ["dockerfile", "docker-compose"],
-      "groupName": "all dependencies on Docker",
+      "matchUpdateTypes": ["patch", "minor"],
+      "groupName": "all minor, or patch dependencies on Docker",
     },
     {
       "matchManagers": ["github-actions"],

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -1,0 +1,29 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": [
+    "config:base",
+  ],
+  "labels": ["dependencies"],
+  "packageRules": [
+    {
+      "matchManagers": ["dockerfile", "docker-compose"],
+      "groupName": "all dependencies on Docker",
+    },
+    {
+      "matchManagers": ["github-actions"],
+      "groupName": "all dependencies on GitHub Actions",
+    },
+    {
+      "matchManagers": ["npm"],
+      "matchUpdateTypes": ["patch", "minor"],
+      "excludePackageNames": ["video.js"], // because CI was failed
+      "groupName": "all minor, or patch dependencies on npm",
+    },
+  ],
+  "enabledManagers": [
+    "dockerfile",
+    "docker-compose",
+    "github-actions",
+    "npm",
+  ],
+}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,7 +5,7 @@ on: push
 jobs:
   build:
     runs-on: ubuntu-latest
-    if: ${{ ! contains(github.event.pull_request.title, '[dreamkast-releasebot]') }}
+    if: github.event.pusher.name != 'dreamkast-cloudnativedays'
     steps:
       - uses: actions/checkout@v3
 

--- a/.github/workflows/eslint.yml
+++ b/.github/workflows/eslint.yml
@@ -10,7 +10,7 @@ jobs:
   eslint:
     name: eslint
     runs-on: ubuntu-latest
-    if: ${{ ! contains(github.event.pull_request.title, '[dreamkast-releasebot]') }}
+    if: github.event.pusher.name != 'dreamkast-cloudnativedays'
     steps:
       - uses: actions/checkout@v3
       - name: Set up Node.js 16.17.0

--- a/.github/workflows/gitops-prd.yml
+++ b/.github/workflows/gitops-prd.yml
@@ -80,5 +80,5 @@ jobs:
               owner: "cloudnativedaysjp",
               repo: "dreamkast-infra",
               pull_number: pr.data.number,
-              merge_method: "merge",
+              merge_method: "squash",
             });

--- a/.github/workflows/gitops-prd.yml
+++ b/.github/workflows/gitops-prd.yml
@@ -2,10 +2,6 @@ name: GitOps for production
 
 on:
   push:
-    paths-ignore:
-      - '.github/**'
-      - '!.github/workflows/gitops-prd.yml'
-      - '**.md'
     tags:
       - v*
 

--- a/.github/workflows/gitops-stg.yml
+++ b/.github/workflows/gitops-stg.yml
@@ -80,5 +80,5 @@ jobs:
               owner: "cloudnativedaysjp",
               repo: "dreamkast-infra",
               pull_number: pr.data.number,
-              merge_method: "merge",
+              merge_method: "squash",
             });

--- a/.github/workflows/gitops-stg.yml
+++ b/.github/workflows/gitops-stg.yml
@@ -2,10 +2,6 @@ name: GitOps for staging
 
 on:
   push:
-    paths-ignore:
-      - '.github/**'
-      - '!.github/workflows/gitops-stg.yml'
-      - '**.md'
     branches:
     - main
 

--- a/.github/workflows/jest.yml
+++ b/.github/workflows/jest.yml
@@ -10,7 +10,7 @@ jobs:
   jest:
     name: jest
     runs-on: ubuntu-latest
-    if: ${{ ! contains(github.event.pull_request.title, '[dreamkast-releasebot]') }}
+    if: github.event.pusher.name != 'dreamkast-cloudnativedays'
     steps:
       - uses: actions/checkout@v3
       - name: Set up Node.js 16.17.0

--- a/.github/workflows/push-tag-by-releasebot.yml
+++ b/.github/workflows/push-tag-by-releasebot.yml
@@ -1,0 +1,42 @@
+name: Push a new tag with merged Pull Request
+
+on:
+  pull_request:
+    types: [closed]
+
+jobs:
+  tagging:
+    runs-on: ubuntu-latest
+    if: contains(github.event.pull_request.title, '[dreamkast-releasebot]')
+    steps:
+      - name: Generate token
+        id: generate_token
+        uses: tibdex/github-app-token@v1
+        with:
+          app_id: ${{ secrets.APP_ID }}
+          private_key: ${{ secrets.PRIVATE_KEY }}
+
+      - uses: actions/checkout@v3
+        with:
+          token: ${{ steps.generate_token.outputs.token }}
+
+      - uses: actions-ecosystem/action-release-label@v1
+        id: release-label
+        if: ${{ github.event.pull_request.merged == true }}
+
+      - uses: actions-ecosystem/action-get-latest-tag@v1
+        id: get-latest-tag
+        if: ${{ steps.release-label.outputs.level != null }}
+
+      - uses: actions-ecosystem/action-bump-semver@v1
+        id: bump-semver
+        if: ${{ steps.release-label.outputs.level != null }}
+        with:
+          current_version: ${{ steps.get-latest-tag.outputs.tag }}
+          level: ${{ steps.release-label.outputs.level }}
+
+      - uses: actions-ecosystem/action-push-tag@v1
+        if: ${{ steps.release-label.outputs.level != null }}
+        with:
+          tag: ${{ steps.bump-semver.outputs.new_version }}
+          message: '${{ steps.bump-semver.outputs.new_version }}: PR #${{ github.event.pull_request.number }} ${{ github.event.pull_request.title }}'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,41 +1,17 @@
-name: Push a new tag with Pull Request
+name: Release
 
 on:
-  pull_request:
-    types: [closed]
+  push:
+    tags:
+      - "v*.*.*"
 
 jobs:
-  release:
+  build:
     runs-on: ubuntu-latest
-    if: ${{ contains(github.event.pull_request.title, '[dreamkast-releasebot]') }}
     steps:
-      - uses: actions/checkout@v3
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Release
+        uses: softprops/action-gh-release@v1
         with:
-          persist-credentials: false
-
-      - uses: actions-ecosystem/action-release-label@v1
-        id: release-label
-        if: ${{ github.event.pull_request.merged == true }}
-
-      - uses: actions-ecosystem/action-get-latest-tag@v1
-        id: get-latest-tag
-        if: ${{ steps.release-label.outputs.level != null }}
-
-      - uses: actions-ecosystem/action-bump-semver@v1
-        id: bump-semver
-        if: ${{ steps.release-label.outputs.level != null }}
-        with:
-          current_version: ${{ steps.get-latest-tag.outputs.tag }}
-          level: ${{ steps.release-label.outputs.level }}
-
-      - name: set credential
-        env:
-          PERSONAL_ACCESS_TOKEN: ${{ secrets.PERSONAL_ACCESS_TOKEN }}
-        run: |
-          git config remote.origin.url https://${GITHUB_ACTOR}:${PERSONAL_ACCESS_TOKEN}@github.com/${GITHUB_REPOSITORY}
-
-      - uses: actions-ecosystem/action-push-tag@v1
-        if: ${{ steps.release-label.outputs.level != null }}
-        with:
-          tag: ${{ steps.bump-semver.outputs.new_version }}
-          message: '${{ steps.bump-semver.outputs.new_version }}: PR #${{ github.event.pull_request.number }} ${{ github.event.pull_request.title }}'
+          generate_release_notes: true

--- a/renovate.json
+++ b/renovate.json
@@ -1,6 +1,0 @@
-{
-  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": [
-    "config:base"
-  ]
-}


### PR DESCRIPTION
## What's changed

* renovate
    * npm (minor, patch バージョンのみ), github-action, docker系(minor, patch バージョンのみ) でそれぞれグループ化した (グループ化した単位で PR が作成される)
        * video.js は cloudnativedaysjp/dreamkast#1494 にて CI がコケているため npm のグループから除外
    * renovate 産の PR には`dependencies` ラベルを付与
* .github/release.yml
    * GitHub Release のテンプレートを記述
        * 具体例: https://github.com/cloudnativedaysjp/seaman/releases/tag/v0.0.4
* Actions
    * 0d728fd
        * rename: release.yml > push-tag-by-releasebot.yml
        * create release.yml : タグが付与されたら GitHub Release を作成する
        * update gitops-*.yml: dreamkast-infra リポジトリに出した PR を squash merge するようにした
    * eebbe48
        * seaman によるリリース用 PR にて以下の action が走らないようにした
            * build.yml
            * eslint.yml
            * jest.yml
        * gitops-*.yml において不要行を削除