### PR TITLE
Add .prettierignore to prevent lint check of generated codes

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,3 @@
+.next
+client-axios
+generated


### PR DESCRIPTION
perttierがgeneratedなコードや.next配下も対象としていて、時間がかかっていた & 不必要なコード修正になっていたので、ignoreするようにしました