### PR TITLE
fix: Add missing props of ChatBox to enable Chat deletion

### DIFF
--- a/src/components/Chat/Chat.tsx
+++ b/src/components/Chat/Chat.tsx
@@ -194,6 +194,7 @@ export const Chat: React.FC<Props> = ({ event, profile, talk }) => {
           </Styled.TabContainer>
           <Styled.TabPanel value="0">
             <ChatBox
+              event={event}
               profile={profile}
               talk={talk}
               messages={messages}
@@ -210,6 +211,7 @@ export const Chat: React.FC<Props> = ({ event, profile, talk }) => {
           </Styled.TabPanel>
           <Styled.TabPanel value="1">
             <ChatBox
+              event={event}
               talk={talk}
               messages={messages}
               messageTypes={[ChatMessageMessageTypeEnum.Qa]}


### PR DESCRIPTION
ChatBoxのevent propsに値が設定されておらず、結果としてchat削除時のガード節を突破できず削除ができない状態になっていたので、eventを追加しました。

```TypeScript
  const onMenuClick = (e: React.MouseEvent<HTMLElement>) => {
    const selectedMessageId = e.currentTarget.getAttribute('data-messageId')
    if (!selectedMessageId || !event) return  // <- ここでこけてしまいます
    const api = new ChatMessageApi(
      new Configuration({ basePath: window.location.origin }),
    )
    const newChatMessage = {
      eventAbbr: event.abbr,
      body: 'このメッセージは削除されました',
    }
    api.apiV1ChatMessagesMessageIdPut(selectedMessageId, newChatMessage)
    setAnchorEl(null)
  }
```

特にconsole.errorをはいたりthrowしたりしないので、サイレントな不具合になっていたように見えます。
一通り動作確認して動いていそうではありますが、コードを全て追いかけることはできていないので、まずいケースがあればご指摘いただけると助かります（eventが設定されている方が正しい状態に見えるので、大丈夫だとは思うのですが）