### PR TITLE
401 error handling on RTK BaseQuery

### DIFF
--- a/src/store/baseApi.ts
+++ b/src/store/baseApi.ts
@@ -8,37 +8,36 @@ import {
 import { HYDRATE } from 'next-redux-wrapper'
 import { retry } from './retry'
 import { RootState } from './index'
+import { reauth } from './reauth'
 
 const createBaseQuery = (baseUrl: string) => {
-  return retry(
-    fetchBaseQuery({
-      baseUrl,
-      prepareHeaders: (headers, { getState }) => {
-        const token = (getState() as RootState).auth.token
+  const baseQuery = fetchBaseQuery({
+    baseUrl,
+    prepareHeaders: (headers, { getState }) => {
+      const token = (getState() as RootState).auth.token
 
-        // TODO reconsider that API call without token should be passed
-        if (token) {
-          headers.set('authorization', `Bearer ${token}`)
-        }
-        return headers
-      },
-    }),
-    {
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      maxRetries: 3 as any,
-      // 400番台はretryしません. 以下のPRがマージされたら、自前のretryを廃止します
-      // https://github.com/reduxjs/redux-toolkit/pull/2239
-      retryCondition: (error, _, { attempt, extraOptions: { maxRetries } }) => {
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        const status: number =
-          error.status || (error as any).error.originalStatus
-
-        return (
-          !(400 <= status && status < 500) && attempt < (maxRetries as number)
-        )
-      },
+      // TODO reconsider that API call without token should be passed
+      if (token) {
+        headers.set('authorization', `Bearer ${token}`)
+      }
+      return headers
     },
-  )
+  })
+
+  return retry(reauth(baseQuery), {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    maxRetries: 3 as any,
+    // 400番台はretryしません. 以下のPRがマージされたら、自前のretryを廃止します
+    // https://github.com/reduxjs/redux-toolkit/pull/2239
+    retryCondition: (error, _, { attempt, extraOptions: { maxRetries } }) => {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const status: number = error.status || (error as any).error.originalStatus
+
+      return (
+        !(400 <= status && status < 500) && attempt < (maxRetries as number)
+      )
+    },
+  })
 }
 
 const dynamicBaseQuery: BaseQueryFn<

--- a/src/store/reauth.ts
+++ b/src/store/reauth.ts
@@ -1,0 +1,26 @@
+import { BaseQueryEnhancer } from '@reduxjs/toolkit/dist/query'
+import { QueryReturnValue } from '@reduxjs/toolkit/dist/query/baseQueryTypes'
+import { MaybePromise } from '@reduxjs/toolkit/dist/query/tsHelpers'
+
+export type ReauthOptions = Record<string, never>
+
+export const reauth: BaseQueryEnhancer<
+  unknown,
+  ReauthOptions,
+  ReauthOptions | void
+> = (baseQuery, _) => {
+  return async (args, api, extraOptions) => {
+    const result = await baseQuery(args, api, extraOptions)
+    if (result.error) {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const status = (result.meta as any).response.status
+      if (status === 401) {
+        console.warn('Redirect to conference top since unauthenticated')
+        // TODO resolve dreamkast URL in an appropriate way
+        window.location.href = `${window.location.href.replace(/\/ui/g, '')}`
+      }
+    }
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    return result as MaybePromise<QueryReturnValue<any, any, any>>
+  }
+}


### PR DESCRIPTION
dk-uiで401になったときにdkに飛ばして再度認証を要求する処理が局所的に入っている状態だったので、RTK Queryのapi clientで一元的に処理するようにしました。

リダイレクト処理は、ここから引っ張って来ています。
https://github.com/cloudnativedaysjp/dreamkast-ui/pull/305/files#r996382108
ドメイン分離するとこの処理だと動かなくなりますが、分割後も対応できるように作り込むとYAGNIになってしまうので、一旦このままとさせてください。