### PR TITLE
enable pre-wrap to display abstract

### DIFF
--- a/src/components/TalkInfo/styled.ts
+++ b/src/components/TalkInfo/styled.ts
@@ -39,6 +39,7 @@ export const Speaker = styled.div`
 `
 
 export const Content = styled.div`
+  white-space: pre-wrap;
   padding: 10px 0;
   height: 230px;
   font-size: 1.1em;


### PR DESCRIPTION
セッション概要に改行などが含まれている場合、それを表示に反映したいのでCSSを設定します