### PR TITLE
Layout for in-person attendees

### DIFF
--- a/src/components/Chat/Chat.tsx
+++ b/src/components/Chat/Chat.tsx
@@ -204,55 +204,53 @@ export const Chat: React.FC<Props> = ({ event, talk }) => {
   }
 
   return (
-    <Styled.Outer>
-      <Styled.Container>
-        <TabContext value={selectedTab}>
-          <Styled.TabContainer
-            value={selectedTab}
-            onChange={onTabSelected}
-            textColor="secondary"
-            aria-label="simple tabs example"
-          >
-            <Styled.Tab label="Chat / QA" value="0" {...a11yProps(0)} />
-            <Styled.Tab label="QA Only" value="1" {...a11yProps(1)} />
-          </Styled.TabContainer>
-          <Styled.TabPanel value="0">
-            <ChatBox
-              event={event}
-              talk={talk}
-              messages={messages}
-              messageTypes={['chat', 'qa']}
-              selectedMessage={selectedMessage}
-              checked={checked}
-              onClickReplyButton={onClickReplyButton}
-              onSendReply={onSendReply}
-              onClickCloseButton={onClickCloseButton}
-            />
-          </Styled.TabPanel>
-          <Styled.TabPanel value="1">
-            <ChatBox
-              event={event}
-              talk={talk}
-              messages={messages}
-              messageTypes={['qa']}
-              selectedMessage={selectedMessage}
-              checked={checked}
-              onClickReplyButton={onClickReplyButton}
-              onClickCloseButton={onClickCloseButton}
-              onSendReply={onSendReply}
-            />
-          </Styled.TabPanel>
-        </TabContext>
-        <ChatMessageForm
-          isVisibleForm={isVisibleForm}
-          selectedMessage={selectedMessage}
-          onClickCloseButton={onClickCloseButton}
-          onSendMessage={onSendReply}
-          onSendQuestion={onSendQuestion}
-          onCheck={onChecked}
-          checked={checked}
-        />
-      </Styled.Container>
-    </Styled.Outer>
+    <Styled.Container>
+      <TabContext value={selectedTab}>
+        <Styled.TabContainer
+          value={selectedTab}
+          onChange={onTabSelected}
+          textColor="secondary"
+          aria-label="simple tabs example"
+        >
+          <Styled.Tab label="Chat / QA" value="0" {...a11yProps(0)} />
+          <Styled.Tab label="QA Only" value="1" {...a11yProps(1)} />
+        </Styled.TabContainer>
+        <Styled.TabPanel value="0">
+          <ChatBox
+            event={event}
+            talk={talk}
+            messages={messages}
+            messageTypes={['chat', 'qa']}
+            selectedMessage={selectedMessage}
+            checked={checked}
+            onClickReplyButton={onClickReplyButton}
+            onSendReply={onSendReply}
+            onClickCloseButton={onClickCloseButton}
+          />
+        </Styled.TabPanel>
+        <Styled.TabPanel value="1">
+          <ChatBox
+            event={event}
+            talk={talk}
+            messages={messages}
+            messageTypes={['qa']}
+            selectedMessage={selectedMessage}
+            checked={checked}
+            onClickReplyButton={onClickReplyButton}
+            onClickCloseButton={onClickCloseButton}
+            onSendReply={onSendReply}
+          />
+        </Styled.TabPanel>
+      </TabContext>
+      <ChatMessageForm
+        isVisibleForm={isVisibleForm}
+        selectedMessage={selectedMessage}
+        onClickCloseButton={onClickCloseButton}
+        onSendMessage={onSendReply}
+        onSendQuestion={onSendQuestion}
+        onCheck={onChecked}
+        checked={checked}
+      />
+    </Styled.Container>
   )
 }

--- a/src/components/Chat/Chat.tsx
+++ b/src/components/Chat/Chat.tsx
@@ -12,14 +12,12 @@ import {
   Event,
   GetApiV1ChatMessagesApiArg,
   GetApiV1ChatMessagesApiResponse,
-  Profile,
   Talk,
   usePostApiV1ChatMessagesMutation,
 } from '../../generated/dreamkast-api.generated'
 
 type Props = {
   event: Event
-  profile?: Profile
   talk?: Talk
 }
 
@@ -93,7 +91,7 @@ const { useGetApiV1ChatMessagesQuery } = dreamkastApi.injectEndpoints({
   overrideExisting: true,
 })
 
-export const Chat: React.FC<Props> = ({ event, profile, talk }) => {
+export const Chat: React.FC<Props> = ({ event, talk }) => {
   const initialChatMessage = {
     eventAbbr: event.abbr,
     body: '',
@@ -221,7 +219,6 @@ export const Chat: React.FC<Props> = ({ event, profile, talk }) => {
           <Styled.TabPanel value="0">
             <ChatBox
               event={event}
-              profile={profile}
               talk={talk}
               messages={messages}
               messageTypes={['chat', 'qa']}

--- a/src/components/Chat/internal/ChatBox/ChatBox.tsx
+++ b/src/components/Chat/internal/ChatBox/ChatBox.tsx
@@ -6,13 +6,11 @@ import { MessageInputs } from '../ChatMessageRequest'
 import {
   Event,
   ChatMessageProperties,
-  Profile,
   Talk,
 } from '../../../../generated/dreamkast-api.generated'
 
 type Props = {
   event?: Event
-  profile?: Profile
   talk?: Talk
   messages: ChatMessageMap
   messageTypes: ChatMessageProperties['messageType'][]
@@ -25,7 +23,6 @@ type Props = {
 
 export const ChatBox: React.FC<Props> = ({
   event,
-  profile,
   talk,
   messages,
   messageTypes,
@@ -46,7 +43,6 @@ export const ChatBox: React.FC<Props> = ({
           return (
             <ChatMessage
               event={event}
-              profile={profile}
               talk={talk}
               key={chatMessage.id}
               chatMessage={chatMessage}

--- a/src/components/Chat/internal/ChatBox/ChatMessageMenu/ChatMessageMenu.tsx
+++ b/src/components/Chat/internal/ChatBox/ChatMessageMenu/ChatMessageMenu.tsx
@@ -2,10 +2,10 @@ import React from 'react'
 import * as Styled from './styled'
 import { Menu, MenuItem } from '@material-ui/core'
 import { ChatMessageContainer } from '../../../../../util/chat'
-import { Profile } from '../../../../../generated/dreamkast-api.generated'
+import { settingsSelector } from '../../../../../store/settings'
+import { useSelector } from 'react-redux'
 
 type Props = {
-  profile?: Profile
   chatMessage?: ChatMessageContainer
   anchorEl?: null | HTMLElement
   onClose: () => void
@@ -13,12 +13,12 @@ type Props = {
 }
 
 export const ChatMessageMenu: React.FC<Props> = ({
-  profile,
   chatMessage,
   anchorEl,
   onClose,
   onMenuClick,
 }) => {
+  const { profile } = useSelector(settingsSelector)
   const menuItemDisabled = () => {
     return !(
       chatMessage?.profileId == profile?.id &&

--- a/src/components/Chat/internal/ChatBox/internal/ChatMessage/ChatMessage.tsx
+++ b/src/components/Chat/internal/ChatBox/internal/ChatMessage/ChatMessage.tsx
@@ -12,7 +12,6 @@ import { ChatMessageMenu } from '../../ChatMessageMenu'
 import { Grid } from '@material-ui/core'
 import {
   Event,
-  Profile,
   Talk,
   usePutApiV1ChatMessagesByMessageIdMutation,
 } from '../../../../../../generated/dreamkast-api.generated'
@@ -22,7 +21,6 @@ dayjs.extend(utc)
 
 type Props = {
   event?: Event
-  profile?: Profile
   talk?: Talk
   chatMessage?: ChatMessageContainer
   selected: boolean
@@ -33,7 +31,6 @@ type Props = {
 
 export const ChatMessage: React.FC<Props> = ({
   event,
-  profile,
   talk,
   chatMessage,
   selected,
@@ -147,7 +144,6 @@ export const ChatMessage: React.FC<Props> = ({
         })}
 
       <ChatMessageMenu
-        profile={profile}
         chatMessage={message}
         anchorEl={anchorEl}
         onClose={closeChatMessageMenu}

--- a/src/components/Chat/styled.ts
+++ b/src/components/Chat/styled.ts
@@ -2,9 +2,7 @@ import styled from 'styled-components'
 import { TabPanel as MUITabPanel } from '@material-ui/lab'
 import { Tabs, Tab as MUITab } from '@material-ui/core'
 
-export const Outer = styled.div`
-  padding: 5px;
-`
+export const Outer = styled.div``
 
 export const Container = styled.div`
   border-radius: 10px;

--- a/src/components/Chat/styled.ts
+++ b/src/components/Chat/styled.ts
@@ -2,8 +2,6 @@ import styled from 'styled-components'
 import { TabPanel as MUITabPanel } from '@material-ui/lab'
 import { Tabs, Tab as MUITab } from '@material-ui/core'
 
-export const Outer = styled.div``
-
 export const Container = styled.div`
   border-radius: 10px;
 `

--- a/src/components/IvsPlayer/IvsPlayer.tsx
+++ b/src/components/IvsPlayer/IvsPlayer.tsx
@@ -5,10 +5,7 @@ import 'video.js/dist/video-js.css'
 import * as Styled from './styled'
 import * as CommonStyled from '../../styles/styled'
 import { Talk } from '../../generated/dreamkast-api.generated'
-import { setShowVideo } from '../../store/settings'
-import { Button } from '@material-ui/core'
-import { VideocamOff } from '@material-ui/icons'
-import { useDispatch } from 'react-redux'
+import { VideoToggleButton } from '../common/VideoToggleButton'
 
 type Props = {
   playBackUrl?: string | null
@@ -38,7 +35,6 @@ export const IvsPlayer: React.FC<Props> = ({
   const videoElement = useRef<HTMLVideoElement>(null)
   const [counter, setCounter] = useState<number>(5)
   const [timer, setTimer] = useState<NodeJS.Timer>()
-  const dispatch = useDispatch()
 
   const cancelUpdate = () => {
     clearInterval(timer as NodeJS.Timer)
@@ -125,18 +121,7 @@ export const IvsPlayer: React.FC<Props> = ({
           </Styled.OverLayContainer>
         )}
       </Styled.IvsPlayerContainer>
-      {showStopVideoButton && (
-        <Button
-          variant="contained"
-          size="small"
-          color="primary"
-          disableElevation
-          startIcon={<VideocamOff />}
-          onClick={() => dispatch(setShowVideo(false))}
-        >
-          Stop Video
-        </Button>
-      )}
+      {showStopVideoButton && <VideoToggleButton />}
     </CommonStyled.Container>
   )
 }

--- a/src/components/IvsPlayer/IvsPlayer.tsx
+++ b/src/components/IvsPlayer/IvsPlayer.tsx
@@ -5,6 +5,10 @@ import 'video.js/dist/video-js.css'
 import * as Styled from './styled'
 import * as CommonStyled from '../../styles/styled'
 import { Talk } from '../../generated/dreamkast-api.generated'
+import { setShowVideo } from '../../store/settings'
+import { Button } from '@material-ui/core'
+import { VideocamOff } from '@material-ui/icons'
+import { useDispatch } from 'react-redux'
 
 type Props = {
   playBackUrl?: string | null
@@ -13,6 +17,7 @@ type Props = {
   nextTalk?: Talk
   updateView: () => void
   stopUpdate: () => void
+  showStopVideoButton?: boolean
 }
 
 declare function registerIVSTech(
@@ -27,11 +32,13 @@ export const IvsPlayer: React.FC<Props> = ({
   nextTalk,
   updateView,
   stopUpdate,
+  showStopVideoButton = false,
 }) => {
   const playerRef = useRef<VideoJsPlayer>()
   const videoElement = useRef<HTMLVideoElement>(null)
   const [counter, setCounter] = useState<number>(5)
   const [timer, setTimer] = useState<NodeJS.Timer>()
+  const dispatch = useDispatch()
 
   const cancelUpdate = () => {
     clearInterval(timer as NodeJS.Timer)
@@ -118,6 +125,18 @@ export const IvsPlayer: React.FC<Props> = ({
           </Styled.OverLayContainer>
         )}
       </Styled.IvsPlayerContainer>
+      {showStopVideoButton && (
+        <Button
+          variant="contained"
+          size="small"
+          color="primary"
+          disableElevation
+          startIcon={<VideocamOff />}
+          onClick={() => dispatch(setShowVideo(false))}
+        >
+          Stop Video
+        </Button>
+      )}
     </CommonStyled.Container>
   )
 }

--- a/src/components/IvsPlayer/__tests__/__snapshots__/IvsPlayer.spec.tsx.snap
+++ b/src/components/IvsPlayer/__tests__/__snapshots__/IvsPlayer.spec.tsx.snap
@@ -2,7 +2,7 @@
 
 exports[`IvsPlayer 1`] = `
 <div
-  className="styled__Container-sc-86hpyq-0 jnikCc"
+  className="styled__Container-sc-86hpyq-0 cDXyjC"
 >
   <div
     className="styled__IvsPlayerContainer-sc-1l56t7n-0 htNCDq"

--- a/src/components/Layout/__tests__/__snapshots__/Layout.spec.tsx.snap
+++ b/src/components/Layout/__tests__/__snapshots__/Layout.spec.tsx.snap
@@ -226,7 +226,7 @@ exports[`Layout 1`] = `
     </header>
   </header>
   <div
-    className="styled__ChildrenContainer-sc-mskfle-3 cpmldw"
+    className="styled__ChildrenContainer-sc-mskfle-3 bDrlxK"
   />
   <footer
     className="styled__Footer-sc-mskfle-4 iIYFwr"

--- a/src/components/Layout/styled.ts
+++ b/src/components/Layout/styled.ts
@@ -23,6 +23,7 @@ export const HeaderImg = styled.img`
 `
 
 export const ChildrenContainer = styled.div`
+  min-height: calc(94vh - 64px);
   background: rgba(255, 255, 255, 0.6);
   padding-bottom: 22px;
 `

--- a/src/components/Layout/styled.ts
+++ b/src/components/Layout/styled.ts
@@ -25,7 +25,7 @@ export const HeaderImg = styled.img`
 export const ChildrenContainer = styled.div`
   min-height: calc(94vh - 64px);
   background: rgba(255, 255, 255, 0.6);
-  padding-bottom: 22px;
+  padding: 10px;
 `
 
 export const Footer = styled.footer`

--- a/src/components/Player/__tests__/__snapshots__/Player.spec.tsx.snap
+++ b/src/components/Player/__tests__/__snapshots__/Player.spec.tsx.snap
@@ -2,7 +2,7 @@
 
 exports[`Player 1`] = `
 <div
-  className="styled__Container-sc-86hpyq-0 jnikCc"
+  className="styled__Container-sc-86hpyq-0 cDXyjC"
 >
   <div
     className="styled__PlayerContainer-sc-1l15m1f-0 iALdbe"

--- a/src/components/TalkInfo/TalkInfo.tsx
+++ b/src/components/TalkInfo/TalkInfo.tsx
@@ -52,56 +52,49 @@ export const TalkInfo: React.FC<Props> = ({
   }
 
   return (
-    <Styled.OuterContainer>
-      <Styled.Container>
-        {selectedTalk?.onAir && (
-          <Styled.Live>LIVE 👥 {viewerCount}</Styled.Live>
+    <Styled.Container>
+      {selectedTalk?.onAir && <Styled.Live>LIVE 👥 {viewerCount}</Styled.Live>}
+      {settings.profile.isAttendOffline && (
+        <Button
+          variant="contained"
+          size="small"
+          color="primary"
+          disableElevation
+          startIcon={settings.showVideo ? <VideocamOff /> : <Videocam />}
+          onClick={() => dispatch(setShowVideo(!settings.showVideo))}
+        >
+          {settings.showVideo ? 'Stop Video' : 'Show Video'}
+        </Button>
+      )}
+      <Styled.Title>{selectedTalk?.title}</Styled.Title>
+      <Styled.SpeakerContainer>
+        <Styled.Speaker>
+          {selectedTalk?.speakers
+            .map((speaker) => {
+              return speaker.name
+            })
+            .join(' / ')}
+        </Styled.Speaker>
+        <div style={{ paddingRight: '20px' }} />
+        {selectedTalk?.documentUrl && (
+          <Styled.DocsLink href={selectedTalk?.documentUrl} target="_blank">
+            登壇資料はこちら
+          </Styled.DocsLink>
         )}
-        {settings.profile.isAttendOffline && (
-          <Button
-            variant="contained"
-            size="small"
-            color="primary"
-            disableElevation
-            startIcon={settings.showVideo ? <VideocamOff /> : <Videocam />}
-            onClick={() => dispatch(setShowVideo(!settings.showVideo))}
-          >
-            {settings.showVideo ? 'Stop Video' : 'Show Video'}
-          </Button>
-        )}
-        <Styled.Title>{selectedTalk?.title}</Styled.Title>
-        <Styled.SpeakerContainer>
-          <Styled.Speaker>
-            {selectedTalk?.speakers
-              .map((speaker) => {
-                return speaker.name
-              })
-              .join(' / ')}
-          </Styled.Speaker>
-          <div style={{ paddingRight: '20px' }} />
-          {selectedTalk?.documentUrl && (
-            <Styled.DocsLink href={selectedTalk?.documentUrl} target="_blank">
-              登壇資料はこちら
-            </Styled.DocsLink>
-          )}
-        </Styled.SpeakerContainer>
-        <Styled.Content>{selectedTalk?.abstract}</Styled.Content>
-        <Styled.SocialHeader>
-          <Styled.TalkIcon src={`/${event?.abbr}/ui/talk_icon.png`} />
-          一緒に盛り上がろう
-        </Styled.SocialHeader>
-        <Styled.ButtonContainer>
-          <Styled.ButtonLink
-            href={twitterURL(selectedTrackName)}
-            target="_blank"
-          >
-            <Styled.TweetButton>
-              <Styled.TwitterImg src={`/${event?.abbr}/ui/twitter_logo.png`} />
-              {`tweet #${event?.abbr}_${selectedTrackName}`}
-            </Styled.TweetButton>
-          </Styled.ButtonLink>
-        </Styled.ButtonContainer>
-      </Styled.Container>
-    </Styled.OuterContainer>
+      </Styled.SpeakerContainer>
+      <Styled.Content>{selectedTalk?.abstract}</Styled.Content>
+      <Styled.SocialHeader>
+        <Styled.TalkIcon src={`/${event?.abbr}/ui/talk_icon.png`} />
+        一緒に盛り上がろう
+      </Styled.SocialHeader>
+      <Styled.ButtonContainer>
+        <Styled.ButtonLink href={twitterURL(selectedTrackName)} target="_blank">
+          <Styled.TweetButton>
+            <Styled.TwitterImg src={`/${event?.abbr}/ui/twitter_logo.png`} />
+            {`tweet #${event?.abbr}_${selectedTrackName}`}
+          </Styled.TweetButton>
+        </Styled.ButtonLink>
+      </Styled.ButtonContainer>
+    </Styled.Container>
   )
 }

--- a/src/components/TalkInfo/TalkInfo.tsx
+++ b/src/components/TalkInfo/TalkInfo.tsx
@@ -2,6 +2,10 @@ import React, { useEffect, useState } from 'react'
 import * as Styled from './styled'
 import { Event, Talk } from '../../generated/dreamkast-api.generated'
 import { useGetApiV1TracksByTrackIdViewerCountQuery } from '../../generated/dreamkast-api.generated'
+import { Button } from '@material-ui/core'
+import { useDispatch, useSelector } from 'react-redux'
+import { setShowVideo, settingsSelector } from '../../store/settings'
+import { Videocam, VideocamOff } from '@material-ui/icons'
 
 type Props = {
   event?: Event
@@ -16,7 +20,9 @@ export const TalkInfo: React.FC<Props> = ({
   selectedTrackName,
   selectedTrackId,
 }) => {
+  const dispatch = useDispatch()
   const [viewerCount, setViewerCount] = useState<string>()
+  const settings = useSelector(settingsSelector)
 
   const { data, isError, isLoading, error } =
     useGetApiV1TracksByTrackIdViewerCountQuery(
@@ -50,6 +56,18 @@ export const TalkInfo: React.FC<Props> = ({
       <Styled.Container>
         {selectedTalk?.onAir && (
           <Styled.Live>LIVE 👥 {viewerCount}</Styled.Live>
+        )}
+        {settings.profile.isAttendOffline && (
+          <Button
+            variant="contained"
+            size="small"
+            color="primary"
+            disableElevation
+            startIcon={settings.showVideo ? <VideocamOff /> : <Videocam />}
+            onClick={() => dispatch(setShowVideo(!settings.showVideo))}
+          >
+            {settings.showVideo ? 'Stop Video' : 'Show Video'}
+          </Button>
         )}
         <Styled.Title>{selectedTalk?.title}</Styled.Title>
         <Styled.SpeakerContainer>

--- a/src/components/TalkInfo/TalkInfo.tsx
+++ b/src/components/TalkInfo/TalkInfo.tsx
@@ -2,10 +2,9 @@ import React, { useEffect, useState } from 'react'
 import * as Styled from './styled'
 import { Event, Talk } from '../../generated/dreamkast-api.generated'
 import { useGetApiV1TracksByTrackIdViewerCountQuery } from '../../generated/dreamkast-api.generated'
-import { Button } from '@material-ui/core'
-import { useDispatch, useSelector } from 'react-redux'
-import { setShowVideo, settingsSelector } from '../../store/settings'
-import { Videocam, VideocamOff } from '@material-ui/icons'
+import { useSelector } from 'react-redux'
+import { settingsSelector } from '../../store/settings'
+import { VideoToggleButton } from '../common/VideoToggleButton'
 
 type Props = {
   event?: Event
@@ -20,7 +19,6 @@ export const TalkInfo: React.FC<Props> = ({
   selectedTrackName,
   selectedTrackId,
 }) => {
-  const dispatch = useDispatch()
   const [viewerCount, setViewerCount] = useState<string>()
   const settings = useSelector(settingsSelector)
 
@@ -54,18 +52,7 @@ export const TalkInfo: React.FC<Props> = ({
   return (
     <Styled.Container>
       {selectedTalk?.onAir && <Styled.Live>LIVE 👥 {viewerCount}</Styled.Live>}
-      {settings.profile.isAttendOffline && (
-        <Button
-          variant="contained"
-          size="small"
-          color="primary"
-          disableElevation
-          startIcon={settings.showVideo ? <VideocamOff /> : <Videocam />}
-          onClick={() => dispatch(setShowVideo(!settings.showVideo))}
-        >
-          {settings.showVideo ? 'Stop Video' : 'Show Video'}
-        </Button>
-      )}
+      {settings.profile.isAttendOffline && <VideoToggleButton />}
       <Styled.Title>{selectedTalk?.title}</Styled.Title>
       <Styled.SpeakerContainer>
         <Styled.Speaker>

--- a/src/components/TalkInfo/styled.ts
+++ b/src/components/TalkInfo/styled.ts
@@ -5,9 +5,8 @@ export const Container = styled.div`
   background: rgba(255, 255, 255, 0.7);
   padding: 10px;
   border-radius: 10px;
+  height: 100%;
 `
-
-export const OuterContainer = styled.div``
 
 export const Title = styled.h2`
   color: #423a57;
@@ -40,7 +39,7 @@ export const Speaker = styled.div`
 export const Content = styled.div`
   white-space: pre-wrap;
   padding: 10px 0;
-  height: 230px;
+  max-height: 300px;
   font-size: 1.1em;
   overflow-y: scroll;
   &::-webkit-scrollbar {

--- a/src/components/TalkInfo/styled.ts
+++ b/src/components/TalkInfo/styled.ts
@@ -7,9 +7,7 @@ export const Container = styled.div`
   border-radius: 10px;
 `
 
-export const OuterContainer = styled.div`
-  padding: 0 5px 12px 5px;
-`
+export const OuterContainer = styled.div``
 
 export const Title = styled.h2`
   color: #423a57;

--- a/src/components/TalkInfo/styled.ts
+++ b/src/components/TalkInfo/styled.ts
@@ -20,10 +20,11 @@ export const Title = styled.h2`
 export const Live = styled.span`
   background-color: red;
   color: white;
-  padding: 5px 10px;
+  padding: 5.5px 10px;
   font-weight: bold;
   border-radius: 5px;
   margin-top: 10px;
+  margin-right: 5px;
   display: inline-block;
 `
 

--- a/src/components/TalkSelector/TalkSelector.tsx
+++ b/src/components/TalkSelector/TalkSelector.tsx
@@ -14,6 +14,7 @@ type Props = {
     event: React.ChangeEvent<HTMLInputElement>,
     mode: boolean,
   ) => void
+  small?: boolean
 }
 
 interface TalkWithAvailable extends Talk {
@@ -37,6 +38,7 @@ export const TalkSelector: React.FC<Props> = ({
   isLiveMode,
   selectTalk,
   changeLiveMode,
+  small = false,
 }) => {
   const [talksWithAvailableState, setTalksWithAvailableState] = useState<
     TalkWithAvailable[]
@@ -85,7 +87,7 @@ export const TalkSelector: React.FC<Props> = ({
   return (
     <Styled.Container>
       <Styled.Title>このトラックのセッション</Styled.Title>
-      <Styled.List>
+      <Styled.List height={small ? 350 : 497}>
         {talksWithAvailableState.map((talk) => {
           if (talk.trackId == selectedTrackId) {
             return (

--- a/src/components/TalkSelector/__tests__/__snapshots__/TalkSelector.spec.tsx.snap
+++ b/src/components/TalkSelector/__tests__/__snapshots__/TalkSelector.spec.tsx.snap
@@ -2,7 +2,7 @@
 
 exports[`TalkSelector 1`] = `
 <div
-  className="styled__Container-sc-1piihja-0 ghKsqG"
+  className="styled__Container-sc-1piihja-0"
 >
   <div
     className="styled__Title-sc-1piihja-1 hrbxKr"
@@ -10,7 +10,8 @@ exports[`TalkSelector 1`] = `
     このトラックのセッション
   </div>
   <ul
-    className="MuiList-root styled__List-sc-1piihja-2 uLqLG MuiList-padding"
+    className="MuiList-root styled__List-sc-1piihja-2 TaJvQ MuiList-padding"
+    height={497}
   />
   <div
     className="styled__Footer-sc-1piihja-6 cnpEUB"

--- a/src/components/TalkSelector/styled.ts
+++ b/src/components/TalkSelector/styled.ts
@@ -1,10 +1,7 @@
 import styled from 'styled-components'
 import { List as OriginList, ListItem } from '@material-ui/core'
 
-export const Container = styled.div`
-  height: 500px;
-  padding: 0 5px;
-`
+export const Container = styled.div``
 
 export const Title = styled.div`
   font-size: 16px;
@@ -17,8 +14,8 @@ export const Title = styled.div`
   color: #423a57;
 `
 
-export const List = styled(OriginList)`
-  height: 405px;
+export const List = styled(OriginList)<{ height: number }>`
+  ${(props) => `height: ${props.height}px`};
   border-top: 1px solid #888;
   border-bottom: 1px solid #888;
   overflow-y: scroll;

--- a/src/components/Track/Track.tsx
+++ b/src/components/Track/Track.tsx
@@ -223,6 +223,7 @@ export const TrackView: React.FC<Props> = ({ event, selectedTrack }) => {
             isLiveMode={isLiveMode}
             changeLiveMode={onChecked}
             selectTalk={selectTalk}
+            small
           />
         </Grid>
       </Grid>

--- a/src/components/Track/Track.tsx
+++ b/src/components/Track/Track.tsx
@@ -10,24 +10,20 @@ import dayjs from 'dayjs'
 import 'dayjs/locale/ja'
 import {
   Event,
-  Profile,
   Talk,
   Track,
   useGetApiV1TalksQuery,
 } from '../../generated/dreamkast-api.generated'
+import { useSelector } from 'react-redux'
+import { settingsSelector } from '../../store/settings'
 
 type Props = {
   event: Event
-  profile?: Profile
   selectedTrack: Track | null
   propTalks?: Talk[]
 }
 
-export const TrackView: React.FC<Props> = ({
-  event,
-  profile,
-  selectedTrack,
-}) => {
+export const TrackView: React.FC<Props> = ({ event, selectedTrack }) => {
   const [talks, setTalks] = useState<Talk[]>([])
   const [videoId, setVideoId] = useState<string | null>()
   const [selectedTalk, setSelectedTalk] = useState<Talk>()
@@ -37,15 +33,8 @@ export const TrackView: React.FC<Props> = ({
   const [chatCable, setChatCable] = useState<ActionCable.Cable | null>(null)
   const [nextTalk, setNextTalk] = useState<{ [trackId: number]: Talk }>()
   const beforeTrackId = useRef<number | undefined>(selectedTrack?.id)
-  const [showVideo, setShowVideo] = useState<boolean>(false)
+  const settings = useSelector(settingsSelector)
   const [_, setError] = useState()
-
-  useEffect(() => {
-    if (!profile) {
-      return
-    }
-    setShowVideo(!profile.isAttendOffline)
-  }, [profile])
 
   const dayId = useMemo(() => {
     const today = dayjs(new Date()).tz('Asia/Tokyo').format('YYYY-MM-DD')
@@ -191,12 +180,12 @@ export const TrackView: React.FC<Props> = ({
     )
   }, [selectedTrack, selectedTalk])
 
-  if (!profile) {
+  if (!settings.isInitialized) {
     // TODO show loading
     return <></>
   }
 
-  if (showVideo) {
+  if (settings.showVideo) {
     return (
       <Grid
         container
@@ -216,7 +205,7 @@ export const TrackView: React.FC<Props> = ({
           <Sponsors event={event} />
         </Grid>
         <Grid item xs={12} md={4}>
-          <Chat event={event} profile={profile} talk={selectedTalk} />
+          <Chat event={event} talk={selectedTalk} />
         </Grid>
         <Grid item xs={12} md={8} style={{ height: '100%' }}>
           <TalkInfo
@@ -250,7 +239,7 @@ export const TrackView: React.FC<Props> = ({
           />
         </Grid>
         <Grid item xs={12} md={4}>
-          <Chat event={event} profile={profile} talk={selectedTalk} />
+          <Chat event={event} talk={selectedTalk} />
         </Grid>
         <Grid item xs={12} md={4}>
           <TalkSelector

--- a/src/components/Track/Track.tsx
+++ b/src/components/Track/Track.tsx
@@ -189,7 +189,7 @@ export const TrackView: React.FC<Props> = ({ event, selectedTrack }) => {
     return (
       <Grid
         container
-        spacing={0}
+        spacing={1}
         justifyContent="center"
         alignItems="flex-start"
       >
@@ -229,7 +229,7 @@ export const TrackView: React.FC<Props> = ({ event, selectedTrack }) => {
     )
   } else {
     return (
-      <Grid container spacing={0} justifyContent="center" alignItems="stretch">
+      <Grid container spacing={1} justifyContent="center" alignItems="stretch">
         <Grid item xs={12} md={4}>
           <TalkInfo
             event={event}
@@ -251,7 +251,9 @@ export const TrackView: React.FC<Props> = ({ event, selectedTrack }) => {
             selectTalk={selectTalk}
           />
         </Grid>
-        <Sponsors event={event} />
+        <Grid item md={12}>
+          <Sponsors event={event} />
+        </Grid>
       </Grid>
     )
   }

--- a/src/components/Track/Track.tsx
+++ b/src/components/Track/Track.tsx
@@ -16,6 +16,7 @@ import {
 } from '../../generated/dreamkast-api.generated'
 import { useSelector } from 'react-redux'
 import { settingsSelector } from '../../store/settings'
+import { useMediaQuery, useTheme } from '@material-ui/core'
 
 type Props = {
   event: Event
@@ -34,6 +35,8 @@ export const TrackView: React.FC<Props> = ({ event, selectedTrack }) => {
   const [nextTalk, setNextTalk] = useState<{ [trackId: number]: Talk }>()
   const beforeTrackId = useRef<number | undefined>(selectedTrack?.id)
   const settings = useSelector(settingsSelector)
+  const theme = useTheme()
+  const isSmallerThanMd = !useMediaQuery(theme.breakpoints.up('md'))
   const [_, setError] = useState()
 
   const dayId = useMemo(() => {
@@ -201,6 +204,9 @@ export const TrackView: React.FC<Props> = ({ event, selectedTrack }) => {
             showCountdown={showCountdown}
             updateView={updateView}
             stopUpdate={stopUpdate}
+            showStopVideoButton={
+              isSmallerThanMd && settings.profile.isAttendOffline
+            }
           ></IvsPlayer>
           <Sponsors event={event} />
         </Grid>

--- a/src/components/Track/Track.tsx
+++ b/src/components/Track/Track.tsx
@@ -37,7 +37,15 @@ export const TrackView: React.FC<Props> = ({
   const [chatCable, setChatCable] = useState<ActionCable.Cable | null>(null)
   const [nextTalk, setNextTalk] = useState<{ [trackId: number]: Talk }>()
   const beforeTrackId = useRef<number | undefined>(selectedTrack?.id)
+  const [showVideo, setShowVideo] = useState<boolean>(false)
   const [_, setError] = useState()
+
+  useEffect(() => {
+    if (!profile) {
+      return
+    }
+    setShowVideo(!profile.isAttendOffline)
+  }, [profile])
 
   const dayId = useMemo(() => {
     const today = dayjs(new Date()).tz('Asia/Tokyo').format('YYYY-MM-DD')
@@ -183,40 +191,79 @@ export const TrackView: React.FC<Props> = ({
     )
   }, [selectedTrack, selectedTalk])
 
-  return (
-    <Grid container spacing={0} justifyContent="center" alignItems="flex-start">
-      <Grid item xs={12} md={8}>
-        <IvsPlayer
-          playBackUrl={videoId}
-          nextTalk={getNextTalk()}
-          autoplay={true}
-          showCountdown={showCountdown}
-          updateView={updateView}
-          stopUpdate={stopUpdate}
-        ></IvsPlayer>
+  if (!profile) {
+    // TODO show loading
+    return <></>
+  }
+
+  if (showVideo) {
+    return (
+      <Grid
+        container
+        spacing={0}
+        justifyContent="center"
+        alignItems="flex-start"
+      >
+        <Grid item xs={12} md={8}>
+          <IvsPlayer
+            playBackUrl={videoId}
+            nextTalk={getNextTalk()}
+            autoplay={true}
+            showCountdown={showCountdown}
+            updateView={updateView}
+            stopUpdate={stopUpdate}
+          ></IvsPlayer>
+          <Sponsors event={event} />
+        </Grid>
+        <Grid item xs={12} md={4}>
+          <Chat event={event} profile={profile} talk={selectedTalk} />
+        </Grid>
+        <Grid item xs={12} md={8} style={{ height: '100%' }}>
+          <TalkInfo
+            event={event}
+            selectedTalk={selectedTalk}
+            selectedTrackName={selectedTrack?.name}
+            selectedTrackId={selectedTrack?.id}
+          />
+        </Grid>
+        <Grid item xs={12} md={4} style={{ height: '100%' }}>
+          <TalkSelector
+            selectedTalk={selectedTalk}
+            selectedTrackId={selectedTrack?.id}
+            talks={talks}
+            isLiveMode={isLiveMode}
+            changeLiveMode={onChecked}
+            selectTalk={selectTalk}
+          />
+        </Grid>
+      </Grid>
+    )
+  } else {
+    return (
+      <Grid container spacing={0} justifyContent="center" alignItems="stretch">
+        <Grid item xs={12} md={4}>
+          <TalkInfo
+            event={event}
+            selectedTalk={selectedTalk}
+            selectedTrackName={selectedTrack?.name}
+            selectedTrackId={selectedTrack?.id}
+          />
+        </Grid>
+        <Grid item xs={12} md={4}>
+          <Chat event={event} profile={profile} talk={selectedTalk} />
+        </Grid>
+        <Grid item xs={12} md={4}>
+          <TalkSelector
+            selectedTalk={selectedTalk}
+            selectedTrackId={selectedTrack?.id}
+            talks={talks}
+            isLiveMode={isLiveMode}
+            changeLiveMode={onChecked}
+            selectTalk={selectTalk}
+          />
+        </Grid>
         <Sponsors event={event} />
       </Grid>
-      <Grid item xs={12} md={4}>
-        <Chat event={event} profile={profile} talk={selectedTalk} />
-      </Grid>
-      <Grid item xs={12} md={8} style={{ height: '100%' }}>
-        <TalkInfo
-          event={event}
-          selectedTalk={selectedTalk}
-          selectedTrackName={selectedTrack?.name}
-          selectedTrackId={selectedTrack?.id}
-        />
-      </Grid>
-      <Grid item xs={12} md={4} style={{ height: '100%' }}>
-        <TalkSelector
-          selectedTalk={selectedTalk}
-          selectedTrackId={selectedTrack?.id}
-          talks={talks}
-          isLiveMode={isLiveMode}
-          changeLiveMode={onChecked}
-          selectTalk={selectTalk}
-        />
-      </Grid>
-    </Grid>
-  )
+    )
+  }
 }

--- a/src/components/TrackSelector/__tests__/__snapshots__/TrackSelector.spec.tsx.snap
+++ b/src/components/TrackSelector/__tests__/__snapshots__/TrackSelector.spec.tsx.snap
@@ -2,7 +2,7 @@
 
 exports[`TrackSelector 1`] = `
 <div
-  className="MuiToggleButtonGroup-root styled__TrackMenuContainer-sc-hs19f1-0 eMCVUt"
+  className="MuiToggleButtonGroup-root styled__TrackMenuContainer-sc-hs19f1-0 cEhzLb"
   color="primary"
   role="group"
 >

--- a/src/components/TrackSelector/styled.ts
+++ b/src/components/TrackSelector/styled.ts
@@ -5,7 +5,7 @@ import ToggleButton from '@material-ui/lab/ToggleButton'
 export const TrackMenuContainer = styled(ToggleButtonGroup)`
   width: 100%;
   justify-content: space-between;
-  padding: 20px 6px;
+  padding: 20px 0;
 `
 
 export const MenuItem = styled(ToggleButton)`

--- a/src/components/common/VideoToggleButton.tsx
+++ b/src/components/common/VideoToggleButton.tsx
@@ -1,3 +1,4 @@
+import React from 'react'
 import { Button } from '@material-ui/core'
 import { useDispatch, useSelector } from 'react-redux'
 import { setShowVideo, settingsSelector } from '../../store/settings'

--- a/src/components/common/VideoToggleButton.tsx
+++ b/src/components/common/VideoToggleButton.tsx
@@ -1,0 +1,21 @@
+import { Button } from '@material-ui/core'
+import { useDispatch, useSelector } from 'react-redux'
+import { setShowVideo, settingsSelector } from '../../store/settings'
+import { Videocam, VideocamOff } from '@material-ui/icons'
+
+export const VideoToggleButton = () => {
+  const dispatch = useDispatch()
+  const settings = useSelector(settingsSelector)
+  return (
+    <Button
+      variant="contained"
+      size="small"
+      color="primary"
+      disableElevation
+      startIcon={settings.showVideo ? <VideocamOff /> : <Videocam />}
+      onClick={() => dispatch(setShowVideo(!settings.showVideo))}
+    >
+      {settings.showVideo ? 'Stop Video' : 'Show Video'}
+    </Button>
+  )
+}

--- a/src/pages/[eventAbbr]/ui/index.tsx
+++ b/src/pages/[eventAbbr]/ui/index.tsx
@@ -10,11 +10,13 @@ import {
   useGetApiV1ByEventAbbrMyProfileQuery,
   Track,
 } from '../../../generated/dreamkast-api.generated'
-import { FetchBaseQueryError } from '@reduxjs/toolkit/dist/query'
 import { NextPage } from 'next'
+import { setProfile } from '../../../store/settings'
+import { useDispatch } from 'react-redux'
 
 const IndexPage: NextPage = () => {
   const router = useRouter()
+  const dispatch = useDispatch()
   const eventAbbr = useMemo<string>(() => {
     if (router.asPath !== router.route) {
       const { eventAbbr } = router.query
@@ -32,6 +34,11 @@ const IndexPage: NextPage = () => {
     { eventAbbr },
     { skip },
   )
+  useEffect(() => {
+    if (myProfileQuery.data) {
+      dispatch(setProfile(myProfileQuery.data))
+    }
+  }, [myProfileQuery.data])
 
   const getTrack = () => {
     if (!v1TracksQuery.data) {
@@ -54,13 +61,6 @@ const IndexPage: NextPage = () => {
   )
 
   useEffect(() => {
-    if ((myProfileQuery.error as FetchBaseQueryError)?.status === 403) {
-      const topUrl = window.location.href.replace('/ui', '')
-      window.location.href = topUrl
-    }
-  }, [myProfileQuery.error])
-
-  useEffect(() => {
     const track = getTrack()
     if (track) {
       setSelectedTrack(track)
@@ -75,11 +75,7 @@ const IndexPage: NextPage = () => {
           selectedTrack={selectedTrack}
           selectTrack={selectTrack}
         />
-        <TrackView
-          event={event}
-          profile={myProfileQuery.data}
-          selectedTrack={selectedTrack}
-        />
+        <TrackView event={event} selectedTrack={selectedTrack} />
       </Layout>
     )
   } else {

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -39,7 +39,6 @@ const IndexPage: NextPage = () => {
     { eventAbbr },
     { skip },
   )
-  const profile = myProfileQuery.data
 
   const getInitialSelectedTrack = (): Track | null => {
     if (!tracksQuery.data) {
@@ -78,11 +77,7 @@ const IndexPage: NextPage = () => {
           selectedTrack={selectedTrack}
           selectTrack={setSelectedTrack}
         />
-        <TrackView
-          event={event}
-          profile={profile}
-          selectedTrack={selectedTrack}
-        />
+        <TrackView event={event} selectedTrack={selectedTrack} />
       </Layout>
     )
   } else {

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -4,12 +4,14 @@ import { NextPageContext } from 'next'
 import { createWrapper, Context } from 'next-redux-wrapper'
 import { dreamkastApi } from '../generated/dreamkast-api.generated'
 import auth from './auth'
+import settings from './settings'
 
 const makeStore = (_: Context) => {
   const store = configureStore({
     reducer: {
       [dreamkastApi.reducerPath]: dreamkastApi.reducer,
       [auth.name]: auth.reducer,
+      [settings.name]: settings.reducer,
     },
     middleware: (getDefaultMiddleware) =>
       getDefaultMiddleware().concat(dreamkastApi.middleware),

--- a/src/store/settings.ts
+++ b/src/store/settings.ts
@@ -1,0 +1,39 @@
+import { createSlice, PayloadAction } from '@reduxjs/toolkit'
+import { Profile } from '../generated/dreamkast-api.generated'
+import { RootState } from './index'
+
+type SettingsState = {
+  isInitialized: boolean
+  profile: Profile
+  showVideo: boolean
+}
+
+const initialState: SettingsState = {
+  isInitialized: false,
+  profile: {
+    id: 0,
+    name: '',
+    email: '',
+    isAttendOffline: false,
+  },
+  showVideo: false,
+}
+
+const settingsSlice = createSlice({
+  name: 'settings',
+  initialState,
+  reducers: {
+    setProfile: (state, action: PayloadAction<Profile>) => {
+      state.profile = action.payload
+      state.showVideo = !action.payload.isAttendOffline
+      state.isInitialized = true
+    },
+    setShowVideo: (state, action: PayloadAction<boolean>) => {
+      state.showVideo = action.payload
+    },
+  },
+})
+
+export const { setProfile, setShowVideo } = settingsSlice.actions
+export const settingsSelector = (state: RootState) => state.settings
+export default settingsSlice

--- a/src/styles/styled.ts
+++ b/src/styles/styled.ts
@@ -6,7 +6,7 @@ export const Container = styled.div`
   background: rgba(255, 255, 255, 0.7);
   font-size: 1.2em;
   border-radius: 10px;
-  margin: 5px;
+  margin-bottom: 5px;
   padding: 10px;
 `
 


### PR DESCRIPTION
オフライン参加時にvideoを見せないようにしました。

- settings redux storeを追加
- profileをsettings redux storeに配置して、各componentはredux storeから読み出すように変更（propsのバケツリレーをやめるrefactoringを含む）
- showVideo stateをreduxに追加し、trueのときのみIvsPlayerを描画
- showVideo stateをtoggleするボタンを追加
- 上記ボタンは、オフライン参加のときのみ表示
  - オンライン時はdefaultでvideoが表示され、ボタンが出てこない。オフライン時はdefaultはvideoが表示されず、ボタンが表示されるので、押した場合のみvideo表示に切り替え
- 独自で設定しているmarginがあると切替時にformatが崩れてしまうので、独自marginを極力除去しつつMUIのGridに任せるように修正
  - 結果として要らなくなったouter containerを、simplifyするために除去（refactoring）
- video非表示モード時に高さが短すぎてfooterが真ん中らへんに表示されてしまったので、コンテンツが途中で終わってもfooterは下部に表示されるように修正

video非表示の場合、以下のような画面になります
<img width="1785" alt="image" src="https://user-images.githubusercontent.com/19190276/200005084-5df3cae2-dc95-4bbd-8ff9-fe3bc27ec50a.png">
