### PR TITLE
add link to Guide

### DIFF
--- a/src/components/Layout/Layout.tsx
+++ b/src/components/Layout/Layout.tsx
@@ -5,6 +5,7 @@ import { DesktopMenu, MobileMenu } from '../Menu'
 import AppBar from '@material-ui/core/AppBar'
 import { Event } from '../../generated/dreamkast-api.generated'
 import { TrailMapModal } from '../TrailMap/TrailMapModal'
+import Link from 'next/link'
 
 type Props = {
   children?: ReactNode
@@ -39,11 +40,11 @@ export const Layout: React.FC<Props> = ({
       <header>
         <AppBar position="static">
           <Styled.Header>
-            <a href={`/${event?.abbr}/ui`} rel="noopener noreferrer">
+            <Link href={`/${event?.abbr}/ui`} rel="noopener noreferrer">
               <Styled.HeaderImg
                 src={`/${event?.abbr}/ui/${event?.abbr}_header_logo.png`}
               />
-            </a>
+            </Link>
             <DesktopMenu event={event} url={url} />
           </Styled.Header>
           <MobileMenu event={event} url={url} />

--- a/src/components/Layout/styled.ts
+++ b/src/components/Layout/styled.ts
@@ -20,6 +20,7 @@ export const Header = styled(Toolbar)`
 
 export const HeaderImg = styled.img`
   height: 40px;
+  cursor: pointer;
 `
 
 export const ChildrenContainer = styled.div`

--- a/src/components/Menu/DesktopMenu.tsx
+++ b/src/components/Menu/DesktopMenu.tsx
@@ -22,10 +22,10 @@ export const DesktopMenu: React.FC<Props> = ({ event, url }) => {
         rel="noreferrer"
         target="_blank"
       >
-        <Button style={{ color: '#423A57' }}>Guide</Button>
+        <Button style={{ color: '#423A57' }}>Attendee Guide</Button>
       </CommonStyled.MenuLink>
       <Link href={`/${event?.abbr}/ui/info`} rel="noreferrer">
-        <Button style={{ color: '#423A57' }}>Info</Button>
+        <Button style={{ color: '#423A57' }}>Your Plan</Button>
       </Link>
       <TrailMapButton />
       <CommonStyled.MenuLink href={`/${event?.abbr}/o11y`} rel="noreferrer">

--- a/src/components/Menu/DesktopMenu.tsx
+++ b/src/components/Menu/DesktopMenu.tsx
@@ -17,6 +17,13 @@ export const DesktopMenu: React.FC<Props> = ({ event, url }) => {
       <Link href={`/${event?.abbr}/ui`} rel="noreferrer">
         <Button style={{ color: '#423A57' }}>Top</Button>
       </Link>
+      <CommonStyled.MenuLink
+        href="https://sites.google.com/view/cndt2022-guide"
+        rel="noreferrer"
+        target="_blank"
+      >
+        <Button style={{ color: '#423A57' }}>Guide</Button>
+      </CommonStyled.MenuLink>
       <Link href={`/${event?.abbr}/ui/info`} rel="noreferrer">
         <Button style={{ color: '#423A57' }}>Info</Button>
       </Link>

--- a/src/components/Menu/DesktopMenu.tsx
+++ b/src/components/Menu/DesktopMenu.tsx
@@ -5,6 +5,8 @@ import * as CommonStyled from '../../styles/styled'
 import { Event } from '../../generated/dreamkast-api.generated'
 import Link from 'next/link'
 import { TrailMapButton } from '../TrailMap/TrailMapButton'
+import { useSelector } from 'react-redux'
+import { settingsSelector } from '../../store/settings'
 
 type Props = {
   event?: Event
@@ -12,13 +14,18 @@ type Props = {
 }
 
 export const DesktopMenu: React.FC<Props> = ({ event, url }) => {
+  const settings = useSelector(settingsSelector)
+  const guideUrl = (): string => {
+    if (settings.profile.isAttendOffline) {
+      return 'https://sites.google.com/view/cndt2022-guide/現地参加オフライン'
+    } else {
+      return 'https://sites.google.com/view/cndt2022-guide/オンライン参加'
+    }
+  }
+
   return (
     <Styled.DesktopMenu>
-      <CommonStyled.MenuLink
-        href="https://sites.google.com/view/cndt2022-guide"
-        rel="noreferrer"
-        target="_blank"
-      >
+      <CommonStyled.MenuLink href={guideUrl()} rel="noreferrer" target="_blank">
         <Button style={{ color: '#423A57' }}>Attendee Guide</Button>
       </CommonStyled.MenuLink>
       <Link href={`/${event?.abbr}/ui/info`} rel="noreferrer">

--- a/src/components/Menu/DesktopMenu.tsx
+++ b/src/components/Menu/DesktopMenu.tsx
@@ -14,9 +14,6 @@ type Props = {
 export const DesktopMenu: React.FC<Props> = ({ event, url }) => {
   return (
     <Styled.DesktopMenu>
-      <Link href={`/${event?.abbr}/ui`} rel="noreferrer">
-        <Button style={{ color: '#423A57' }}>Top</Button>
-      </Link>
       <CommonStyled.MenuLink
         href="https://sites.google.com/view/cndt2022-guide"
         rel="noreferrer"

--- a/src/components/Menu/MobileMenu.tsx
+++ b/src/components/Menu/MobileMenu.tsx
@@ -43,7 +43,7 @@ export const MobileMenu: React.FC<Props> = ({ event, url }) => {
             <InfoIcon />
           </ListItemIcon>
           <Link href={`/${event?.abbr}/ui/info`} rel="noreferrer">
-            <Button style={{ color: '#423A57' }}>Info</Button>
+            <Button style={{ color: '#423A57' }}>Your Plan</Button>
           </Link>
         </ListItem>
         <ListItem button key="guide">
@@ -55,7 +55,7 @@ export const MobileMenu: React.FC<Props> = ({ event, url }) => {
             rel="noreferrer"
             target="_blank"
           >
-            <Button style={{ color: '#423A57' }}>Guide</Button>
+            <Button style={{ color: '#423A57' }}>Attendee Guide</Button>
           </CommonStyled.MenuLink>
         </ListItem>
         <ListItem button key="timetable">

--- a/src/components/Menu/MobileMenu.tsx
+++ b/src/components/Menu/MobileMenu.tsx
@@ -21,6 +21,13 @@ export const MobileMenu: React.FC<Props> = ({ event, url }) => {
         <Button style={{ color: '#423A57' }}>Info</Button>
       </Link>
       <TrailMapButton />
+      <CommonStyled.MenuLink
+        href="https://sites.google.com/view/cndt2022-guide"
+        rel="noreferrer"
+        target="_blank"
+      >
+        <Button style={{ color: '#423A57' }}>Guide</Button>
+      </CommonStyled.MenuLink>
       <CommonStyled.MenuLink href={`/${event?.abbr}/o11y`} rel="noreferrer">
         <Button style={{ color: '#423A57' }}>Grafana</Button>
       </CommonStyled.MenuLink>

--- a/src/components/Menu/MobileMenu.tsx
+++ b/src/components/Menu/MobileMenu.tsx
@@ -3,8 +3,14 @@ import Button from '@material-ui/core/Button'
 import * as Styled from './styled'
 import * as CommonStyled from '../../styles/styled'
 import { Event } from '../../generated/dreamkast-api.generated'
-import Link from 'next/link'
+import InfoIcon from '@material-ui/icons/Info'
+import MapIcon from '@material-ui/icons/Map'
+import TableChartIcon from '@material-ui/icons/TableChart'
+import ExitToAppIcon from '@material-ui/icons/ExitToApp'
 import { TrailMapButton } from '../TrailMap/TrailMapButton'
+import MenuIcon from '@material-ui/icons/Menu'
+import { Drawer, List, ListItem, ListItemIcon } from '@material-ui/core'
+import Link from 'next/link'
 
 type Props = {
   event?: Event
@@ -12,34 +18,81 @@ type Props = {
 }
 
 export const MobileMenu: React.FC<Props> = ({ event, url }) => {
+  const [state, setState] = React.useState(false)
+  const toggleDrawer =
+    (open: boolean) => (event: React.KeyboardEvent | React.MouseEvent) => {
+      if (
+        event.type === 'keydown' &&
+        ((event as React.KeyboardEvent).key === 'Tab' ||
+          (event as React.KeyboardEvent).key === 'Shift')
+      ) {
+        return
+      }
+
+      setState(open)
+    }
+  const list = () => (
+    <div
+      role="presentation"
+      onClick={toggleDrawer(false)}
+      onKeyDown={toggleDrawer(false)}
+    >
+      <List>
+        <ListItem button key="info">
+          <ListItemIcon>
+            <InfoIcon />
+          </ListItemIcon>
+          <Link href={`/${event?.abbr}/ui/info`} rel="noreferrer">
+            <Button style={{ color: '#423A57' }}>Info</Button>
+          </Link>
+        </ListItem>
+        <ListItem button key="guide">
+          <ListItemIcon>
+            <MapIcon />
+          </ListItemIcon>
+          <CommonStyled.MenuLink
+            href="https://sites.google.com/view/cndt2022-guide"
+            rel="noreferrer"
+            target="_blank"
+          >
+            <Button style={{ color: '#423A57' }}>Guide</Button>
+          </CommonStyled.MenuLink>
+        </ListItem>
+        <ListItem button key="timetable">
+          <ListItemIcon>
+            <TableChartIcon />
+          </ListItemIcon>
+          <CommonStyled.MenuLink
+            href={`/${event?.abbr}/timetables`}
+            rel="noreferrer"
+          >
+            <Button style={{ color: '#423A57' }}>Timetable</Button>
+          </CommonStyled.MenuLink>
+        </ListItem>
+        <ListItem button key="logout">
+          <ListItemIcon>
+            <ExitToAppIcon />
+          </ListItemIcon>
+          <Button href={url} style={{ color: '#423A57' }}>
+            Logout
+          </Button>
+        </ListItem>
+      </List>
+    </div>
+  )
+
   return (
     <Styled.MobileMenu>
-      <Link href={`/${event?.abbr}/ui`} rel="noreferrer">
-        <Button style={{ color: '#423A57' }}>Top</Button>
-      </Link>
-      <Link href={`/${event?.abbr}/ui/info`} rel="noreferrer">
-        <Button style={{ color: '#423A57' }}>Info</Button>
-      </Link>
+      <Button onClick={toggleDrawer(true)}>
+        <MenuIcon />
+      </Button>
+      <Drawer open={state} onClose={toggleDrawer(false)}>
+        {list()}
+      </Drawer>
       <TrailMapButton />
-      <CommonStyled.MenuLink
-        href="https://sites.google.com/view/cndt2022-guide"
-        rel="noreferrer"
-        target="_blank"
-      >
-        <Button style={{ color: '#423A57' }}>Guide</Button>
-      </CommonStyled.MenuLink>
       <CommonStyled.MenuLink href={`/${event?.abbr}/o11y`} rel="noreferrer">
         <Button style={{ color: '#423A57' }}>Grafana</Button>
       </CommonStyled.MenuLink>
-      <CommonStyled.MenuLink
-        href={`/${event?.abbr}/timetables`}
-        rel="noreferrer"
-      >
-        <Button style={{ color: '#423A57' }}>Timetable</Button>
-      </CommonStyled.MenuLink>
-      <Button href={url} style={{ color: '#423A57' }}>
-        Logout
-      </Button>
     </Styled.MobileMenu>
   )
 }


### PR DESCRIPTION
- 参加ガイドへのリンクを追加
- ロゴのリンクをSPAとして動くように変更
- モバイルで見たときにメニューをDrawerにする

#### Desktop

![image](https://user-images.githubusercontent.com/107187/202878977-61378d24-dc0b-4ca1-86a2-9b43626f06ac.png)

#### Mobile

<img width="451" alt="image" src="https://user-images.githubusercontent.com/107187/202727996-b5af9b4c-f570-4b0a-afa7-8633234eb255.png">

![image](https://user-images.githubusercontent.com/107187/202878984-2eb74c72-3166-47a9-8e7b-8458c09a5f6a.png)

