### PR TITLE
validate chat message length

### DIFF
--- a/src/components/Chat/internal/ChatMessageForm/ChatMessageForm.tsx
+++ b/src/components/Chat/internal/ChatMessageForm/ChatMessageForm.tsx
@@ -87,7 +87,9 @@ export const ChatMessageForm: React.FC<Props> = ({
           {...register('chatMessage', { required: true, maxLength: 512 })}
         />
         {errors.chatMessage?.types?.maxLength && (
-          <Styled.label>一度に書き込める最大文字数は512文字です</Styled.label>
+          <Styled.WarningText>
+            一度に書き込める最大文字数は512文字です
+          </Styled.WarningText>
         )}
 
         <Input type="hidden" {...register('isQuestion')} />

--- a/src/components/Chat/internal/ChatMessageForm/ChatMessageForm.tsx
+++ b/src/components/Chat/internal/ChatMessageForm/ChatMessageForm.tsx
@@ -31,8 +31,12 @@ export const ChatMessageForm: React.FC<Props> = ({
     reset,
     watch,
     getValues,
-    formState: { isSubmitSuccessful },
-  } = useForm<MessageInputs>()
+    formState: { errors, isSubmitSuccessful },
+  } = useForm<MessageInputs>({
+    mode: 'onChange',
+    criteriaMode: 'all',
+    shouldFocusError: false,
+  })
   const [btnDisabled, setBtnDisabled] = useState<boolean>(false)
 
   const watchChatMessage = watch('chatMessage')
@@ -80,8 +84,12 @@ export const ChatMessageForm: React.FC<Props> = ({
           color="secondary"
           size="small"
           onKeyPress={handleKeyPress}
-          {...register('chatMessage')}
+          {...register('chatMessage', { required: true, maxLength: 512 })}
         />
+        {errors.chatMessage?.types?.maxLength && (
+          <Styled.label>一度に書き込める最大文字数は512文字です</Styled.label>
+        )}
+
         <Input type="hidden" {...register('isQuestion')} />
         <Styled.ButtonContainer>
           <ReactionButton

--- a/src/components/Chat/internal/ChatMessageForm/ChatMessageForm.tsx
+++ b/src/components/Chat/internal/ChatMessageForm/ChatMessageForm.tsx
@@ -25,6 +25,7 @@ export const ChatMessageForm: React.FC<Props> = ({
   onSendMessage,
   onSendQuestion,
 }) => {
+  const CHAT_BODY_MAX_LENGTH = 512
   const {
     register,
     handleSubmit,
@@ -72,6 +73,10 @@ export const ChatMessageForm: React.FC<Props> = ({
     }
   }, [isSubmitSuccessful, reset])
 
+  useEffect(() => {
+    setBtnDisabled((watchChatMessage as string).length > CHAT_BODY_MAX_LENGTH)
+  }, [watchChatMessage])
+
   return (
     <Styled.Container>
       {/* {isVisibleForm && ( */}
@@ -84,7 +89,10 @@ export const ChatMessageForm: React.FC<Props> = ({
           color="secondary"
           size="small"
           onKeyPress={handleKeyPress}
-          {...register('chatMessage', { required: true, maxLength: 512 })}
+          {...register('chatMessage', {
+            required: true,
+            maxLength: CHAT_BODY_MAX_LENGTH,
+          })}
         />
         {errors.chatMessage?.types?.maxLength && (
           <Styled.WarningText>

--- a/src/components/Chat/internal/ChatMessageForm/styled.ts
+++ b/src/components/Chat/internal/ChatMessageForm/styled.ts
@@ -46,6 +46,10 @@ export const TextField = styled(MuiTextField)`
   width: 100%;
   padding: 2px 10px !important;
 `
+export const WarningText = styled.div`
+  width: 100%;
+  padding: 2px 10px !important;
+`
 
 export const CheckBoxContainer = styled.div`
   width: 100%;

--- a/src/components/Chat/internal/ChatMessageRequest/index.ts
+++ b/src/components/Chat/internal/ChatMessageRequest/index.ts
@@ -1,4 +1,5 @@
 export type MessageInputs = {
   chatMessage: string
   isQuestion: boolean
+  maxLength?: string
 }


### PR DESCRIPTION
fix https://github.com/cloudnativedaysjp/dreamkast/issues/1689

チャットで送れる文字数のバリデーションをUIでも行います。Dk本体で512文字を上限としているのでUIも揃えておきます。

- 入力した文字数が512文字以上になったらWarningメッセージを表示する
- 入力した文字数が512文字以上になったら送信ボタンを無効にする

以下、上限を越えたときのスクリーンショット（最大文字数は一時的に変更しているので512ではない）

<img width="328" alt="image" src="https://user-images.githubusercontent.com/107187/205955351-f84a7a2e-9c08-4713-a450-2def30702bd6.png">
