### PR TITLE
chore: update build GitHubAction to add docker tag of latest and semver

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -32,6 +32,8 @@ jobs:
           tags: |
             type=sha,prefix=,format=long
             type=ref,event=branch
+            type=ref,event=tag
+            type=raw,value=latest,enable={{is_default_branch}}
 
       - name: Build
         id: docker_build


### PR DESCRIPTION
dk-uiのdocker tagが、commit hashとbranch名だけ付与される形になっていて、latestやsemver tagが付与されていませんでした。
dkの方のdocker-composeではdk-uiの `main` が参照されていましたが、このmainは2021年にビルドされたimageを指していて、docker-composeで起動するdk-uiは機能しない状態でした。

今後複数人で開発していくうえでよろしくないので、docker-compose側はlatestにし、こっちはmain mergeされたらlatest tagがつくように修正します。

docker tagの追加だけなのでセルフマージして、期待値通りにtagがつくか動作確認させてください。