### PR TITLE
Fix: Correct action cable endpoint

### DIFF
--- a/src/components/Chat/Chat.tsx
+++ b/src/components/Chat/Chat.tsx
@@ -25,6 +25,7 @@ import {
 import { settingsSelector } from '../../store/settings'
 import { useSelector } from 'react-redux'
 import { EnvCtx } from '../../context/env'
+import { RootState } from '../../store'
 
 type Props = {
   event: Event
@@ -64,15 +65,12 @@ const { useGetApiV1ChatMessagesQuery } = dreamkastApi.injectEndpoints({
       }),
       async onCacheEntryAdded(
         arg,
-        { updateCachedData, cacheDataLoaded, cacheEntryRemoved },
+        { updateCachedData, cacheDataLoaded, cacheEntryRemoved, getState },
       ) {
         // create a websocket connection when the cache subscription starts
         await cacheDataLoaded
-
-        const wsUrl =
-          window.location.protocol === 'http:'
-            ? `ws://${window.location.host}/cable`
-            : `wss://${window.location.host}/cable`
+        const { wsBaseUrl } = (getState() as RootState).auth
+        const wsUrl = `${wsBaseUrl}cable`
 
         // eslint-disable-next-line @typescript-eslint/no-var-requires
         const actionCable = require('actioncable') // cannot import actioncable at the top of module since it depends on window

--- a/src/components/Track/Track.tsx
+++ b/src/components/Track/Track.tsx
@@ -18,6 +18,7 @@ import { useSelector } from 'react-redux'
 import { settingsSelector } from '../../store/settings'
 import { useMediaQuery, useTheme } from '@material-ui/core'
 import { getSlotId } from '../../util/trailMap'
+import { authSelector } from '../../store/authSelector'
 
 type Props = {
   event: Event
@@ -43,6 +44,7 @@ export const TrackView: React.FC<Props> = ({
   const [nextTalk, setNextTalk] = useState<{ [trackId: number]: Talk }>()
   const beforeTrackId = useRef<number | undefined>(selectedTrack?.id)
   const settings = useSelector(settingsSelector)
+  const { wsBaseUrl } = useSelector(authSelector)
   const theme = useTheme()
   const isSmallerThanMd = !useMediaQuery(theme.breakpoints.up('md'))
   const [_, setError] = useState()
@@ -108,14 +110,6 @@ export const TrackView: React.FC<Props> = ({
     }
   }, [talks])
 
-  const actionCableUrl = () => {
-    if (window.location.protocol == 'http:') {
-      return `ws://${window.location.host}/cable`
-    } else {
-      return `wss://${window.location.host}/cable`
-    }
-  }
-
   const getNextTalk = () => {
     if (selectedTrack && nextTalk) return nextTalk[selectedTrack.id]
   }
@@ -170,8 +164,8 @@ export const TrackView: React.FC<Props> = ({
     if (chatCable) chatCable.disconnect()
     // eslint-disable-next-line @typescript-eslint/no-var-requires
     const actionCable = require('actioncable')
-    const wsUrl = actionCableUrl()
-    const cable = actionCable.createConsumer(wsUrl)
+    const actionCableUrl = `${wsBaseUrl}cable`
+    const cable = actionCable.createConsumer(actionCableUrl)
     setChatCable(cable)
     cable.subscriptions.create(
       { channel: 'OnAirChannel', eventAbbr: event?.abbr },

--- a/src/store/auth.ts
+++ b/src/store/auth.ts
@@ -7,12 +7,14 @@ type AuthState = {
 
   // TODO move to appropriate redux store
   apiBaseUrl: string
+  wsBaseUrl: string
 }
 
 const initialState: AuthState = {
   user: null,
   token: '',
   apiBaseUrl: '',
+  wsBaseUrl: '',
 }
 
 const authSlice = createSlice({
@@ -27,6 +29,7 @@ const authSlice = createSlice({
     },
     setApiBaseUrl: (state, action: PayloadAction<string>) => {
       state.apiBaseUrl = action.payload
+      state.wsBaseUrl = action.payload.replace('http', 'ws')
     },
   },
 })


### PR DESCRIPTION
local devでのbackend accessをcross originにしたのですが、dk-ui側もwebsocketだけはドメイン分離対応前と同じwindow.location.hostを参照していて、環境変数で与えられたbackendを見に行っていなかったので、修正しました。

dreamkast側のallowed-originも直しています: https://github.com/cloudnativedaysjp/dreamkast/pull/1828