### PR TITLE
fix: add NEXT_PUBLIC_DK_URL env var to access dk directly only when using websocket

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -4,6 +4,10 @@ export const ENV = {
   NEXT_PUBLIC_AUTH0_AUDIENCE: process.env.NEXT_PUBLIC_AUTH0_AUDIENCE ?? '',
   NEXT_PUBLIC_BASE_PATH: process.env.NEXT_PUBLIC_BASE_PATH ?? '',
   NEXT_PUBLIC_API_BASE_URL: process.env.NEXT_PUBLIC_API_BASE_URL ?? '',
+  NEXT_PUBLIC_DK_URL:
+    process.env.NEXT_PUBLIC_DK_URL ??
+    process.env.NEXT_PUBLIC_API_BASE_URL ??
+    '',
   NEXT_PUBLIC_EVENT_SALT:
     process.env.NEXT_PUBLIC_EVENT_SALT ?? 'cloudnativedays',
 } as const

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -15,7 +15,7 @@ import { AppProps } from 'next/app'
 import TagManager from 'react-gtm-module'
 import App from 'next/app'
 import { useDispatch, useSelector } from 'react-redux'
-import { setApiBaseUrl, setToken, setUser } from '../store/auth'
+import { setApiBaseUrl, setToken, setUser, setWsBaseUrl } from '../store/auth'
 import { Auth0Provider, useAuth0 } from '@auth0/auth0-react'
 import { ENV, validateEnv } from '../config'
 import { tokenSelector } from '../store/authSelector'
@@ -117,6 +117,7 @@ const WrappedApp = ({ Component, pageProps, env }: WrappedAppProps) => {
 
   useEffect(() => {
     dispatch(setApiBaseUrl(env.NEXT_PUBLIC_API_BASE_URL))
+    dispatch(setWsBaseUrl(env.NEXT_PUBLIC_DK_URL))
   }, [])
 
   useEffect(() => {

--- a/src/store/auth.ts
+++ b/src/store/auth.ts
@@ -29,10 +29,13 @@ const authSlice = createSlice({
     },
     setApiBaseUrl: (state, action: PayloadAction<string>) => {
       state.apiBaseUrl = action.payload
+    },
+    setWsBaseUrl: (state, action: PayloadAction<string>) => {
       state.wsBaseUrl = action.payload.replace('http', 'ws')
     },
   },
 })
 
-export const { setUser, setToken, setApiBaseUrl } = authSlice.actions
+export const { setUser, setToken, setApiBaseUrl, setWsBaseUrl } =
+  authSlice.actions
 export default authSlice


### PR DESCRIPTION
websocketもapi gateway経由でやりたかったのですが、いろいろ作り込みが発生しそうで複雑化しそうだったので、直接dkにアクセスするようにしました。
この対応をmergeしたら、staging/prod環境のマニフェストにも環境変数の追加が必要です