### PR TITLE
Fix improve error handling

### DIFF
--- a/src/components/Layout/ErrorLayout.tsx
+++ b/src/components/Layout/ErrorLayout.tsx
@@ -1,0 +1,46 @@
+import React from 'react'
+import * as Styled from './styled'
+import Head from 'next/head'
+import AppBar from '@material-ui/core/AppBar'
+import Link from 'next/link'
+import { useRouter } from 'next/router'
+
+type Props = {
+  statusCode?: number
+}
+
+export const ErrorLayout = ({ statusCode }: Props) => {
+  const router = useRouter()
+  const eventAbbr = (() => {
+    const { eventAbbr } = router.query
+    return router.isReady ? (eventAbbr as string) : ''
+  })()
+
+  return (
+    <Styled.Container eventAbbr={eventAbbr}>
+      <Head>
+        <title>Error: CloudNative Days player</title>
+        <meta charSet="utf-8" />
+        <meta name="viewport" content="initial-scale=1.0, width=device-width" />
+      </Head>
+      <header>
+        <AppBar position="static">
+          <Styled.Header>
+            <Link href={`/${eventAbbr}/ui`} rel="noopener noreferrer">
+              <Styled.HeaderImg
+                src={`/${eventAbbr}/ui/${eventAbbr}_header_logo.png`}
+              />
+            </Link>
+          </Styled.Header>
+        </AppBar>
+      </header>
+      <Styled.ErrorContainer>
+        <Styled.ErrorMessage>
+          {statusCode || ''} エラーが発生しました。
+          <br />
+          リロードしても問題が継続する場合は、スタッフまでお問い合わせください。
+        </Styled.ErrorMessage>
+      </Styled.ErrorContainer>
+    </Styled.Container>
+  )
+}

--- a/src/components/Layout/styled.ts
+++ b/src/components/Layout/styled.ts
@@ -29,6 +29,23 @@ export const ChildrenContainer = styled.div`
   padding: 10px;
 `
 
+export const ErrorContainer = styled.div`
+  height: calc(100vh - 64px);
+  background: rgba(255, 255, 255, 0.7);
+`
+
+export const ErrorMessage = styled.div`
+  padding: 30px;
+  width: 100%;
+  font-size: 24px;
+  font-weight: bold;
+  text-align: center;
+  top: 50%;
+  left: 50%;
+  position: absolute;
+  transform: translate(-50%, -50%);
+`
+
 export const Footer = styled.footer`
   grid-row-start: 2;
   grid-row-end: 3;

--- a/src/context/auth.tsx
+++ b/src/context/auth.tsx
@@ -1,0 +1,83 @@
+import React, { PropsWithChildren, useEffect, useState } from 'react'
+import { ENV } from '../config'
+import { Auth0Provider, useAuth0 } from '@auth0/auth0-react'
+import { useDispatch, useSelector } from 'react-redux'
+import { setToken, setUser } from '../store/auth'
+import { tokenSelector } from '../store/authSelector'
+
+type Props = {
+  env: typeof ENV
+}
+
+export const AuthProvider = ({ env, children }: PropsWithChildren<Props>) => {
+  const [baseUrl, setBaseUrl] = useState('')
+
+  useEffect(() => {
+    if (!env.NEXT_PUBLIC_BASE_PATH) {
+      console.error('Environment variables are not provided as app props.')
+      return
+    }
+    const url = new URL(env.NEXT_PUBLIC_BASE_PATH, window.location.origin)
+    setBaseUrl(url.href)
+  }, [env])
+
+  // Only CSR is supported since dynamic host origin resolution cannot be performed in SSR.
+  if (!baseUrl || !env.NEXT_PUBLIC_BASE_PATH) {
+    return <></>
+  }
+  return (
+    <>
+      <Auth0Provider
+        domain={env.NEXT_PUBLIC_AUTH0_DOMAIN}
+        clientId={env.NEXT_PUBLIC_AUTH0_CLIENT_ID}
+        redirectUri={baseUrl}
+        audience={env.NEXT_PUBLIC_AUTH0_AUDIENCE}
+      >
+        {children}
+      </Auth0Provider>
+    </>
+  )
+}
+
+export const useAccessToken = () => {
+  const [_, setError] = useState()
+  const dispatch = useDispatch()
+
+  const {
+    user,
+    isAuthenticated,
+    isLoading,
+    getAccessTokenSilently,
+    loginWithRedirect,
+  } = useAuth0()
+
+  useEffect(() => {
+    if (isLoading) {
+      return
+    }
+    if (!isAuthenticated) {
+      loginWithRedirect().catch((err) => {
+        err.message = 'Login with redirect: ' + err.message
+        setError(() => {
+          throw err
+        })
+      })
+      return
+    }
+    if (user) {
+      dispatch(setUser(user))
+    }
+    getAccessTokenSilently()
+      .then((token) => {
+        dispatch(setToken(token))
+      })
+      .catch((err) => {
+        err.message = 'Get token silently: ' + err.message
+        setError(() => {
+          throw err
+        })
+      })
+  }, [isAuthenticated, isLoading])
+
+  return useSelector(tokenSelector)
+}

--- a/src/pages/404.tsx
+++ b/src/pages/404.tsx
@@ -1,0 +1,13 @@
+import * as Styled from '../components/Layout/styled'
+
+const Error404 = () => {
+  return (
+    <Styled.ErrorMessage>
+      404 Not Found
+      <br />
+      ページが存在しません。URLをご確認ください。
+    </Styled.ErrorMessage>
+  )
+}
+
+export default Error404

--- a/src/pages/404.tsx
+++ b/src/pages/404.tsx
@@ -5,7 +5,7 @@ const Error404 = () => {
     <Styled.ErrorMessage>
       404 Not Found
       <br />
-      ページが存在しません。URLをご確認ください。
+      お探しのコンテンツは存在しません。URLをご確認ください。
     </Styled.ErrorMessage>
   )
 }

--- a/src/pages/_error.js
+++ b/src/pages/_error.js
@@ -18,13 +18,14 @@
 
 import * as Sentry from '@sentry/nextjs'
 import NextErrorComponent from 'next/error'
+import { ErrorLayout } from '../components/Layout/ErrorLayout'
 
 const CustomErrorComponent = (props) => {
   // If you're using a Nextjs version prior to 12.2.1, uncomment this to
   // compensate for https://github.com/vercel/next.js/issues/8592
   // Sentry.captureUnderscoreErrorException(props)
 
-  return <NextErrorComponent statusCode={props.statusCode} />
+  return <ErrorLayout statusCode={props.statusCode} />
 }
 
 CustomErrorComponent.getInitialProps = async (contextData) => {

--- a/src/pages/_error.tsx
+++ b/src/pages/_error.tsx
@@ -18,9 +18,14 @@
 
 import * as Sentry from '@sentry/nextjs'
 import NextErrorComponent from 'next/error'
+import { NextPageContext } from 'next'
 import { ErrorLayout } from '../components/Layout/ErrorLayout'
 
-const CustomErrorComponent = (props) => {
+type Props = {
+  statusCode?: number
+}
+
+const CustomErrorComponent = (props: Props) => {
   // If you're using a Nextjs version prior to 12.2.1, uncomment this to
   // compensate for https://github.com/vercel/next.js/issues/8592
   // Sentry.captureUnderscoreErrorException(props)
@@ -28,7 +33,7 @@ const CustomErrorComponent = (props) => {
   return <ErrorLayout statusCode={props.statusCode} />
 }
 
-CustomErrorComponent.getInitialProps = async (contextData) => {
+CustomErrorComponent.getInitialProps = async (contextData: NextPageContext) => {
   // In case this is running in a serverless function, await this in order to give Sentry
   // time to send the error before the lambda exits
   await Sentry.captureUnderscoreErrorException(contextData)


### PR DESCRIPTION
プレイベントで発生した、環境変数バインドなしでauth0のendpointを叩きにいってしまう問題、およびエラーが出たときに適切なエラー画面が出ない問題に対処しました。
具体的には、以下を実施しています。

- Sentryのために追加したerror handlerに、error pageを追加
- 存在しないエンドポイントを叩いて404になった際にもSentryにreportが上がってしまうのを避けるために、404用のエラーページを追加
- 環境変数が失われてしまっている場合は、auth0のendpointを叩きに行く前にfail fastさせる

一部リファクタリングが入っています。
- _app.tsxが責務持ち過ぎだったので、auth関連を分離
- _error.jsをtsx化

エラー画面は以下な感じです。
文言の修正は、コメントいただければ対応します。
デザインがいけてねえ！という場合は、デザインセンスがないのでコミット積んでいただけると助かります:bow:

<img width="1191" alt="image" src="https://user-images.githubusercontent.com/19190276/222185574-2c36ca93-24fe-4f25-9605-bb558c80d8b0.png">

