### PR TITLE
fix: Show selected effect on TrackSelector button group

### DIFF
--- a/src/components/TrackSelector/PTrackSelectorButtonGroup.tsx
+++ b/src/components/TrackSelector/PTrackSelectorButtonGroup.tsx
@@ -46,7 +46,11 @@ export const PTrackSelectorButtonGroup: React.FC<Props> = ({
             </React.Fragment>
           }
         >
-          <Styled.MenuItem key={track.id} value={track.id}>
+          <Styled.MenuItem
+            key={track.id}
+            value={track.id}
+            selected={selectedTrack === track.id}
+          >
             {track.name}
           </Styled.MenuItem>
         </HtmlTooltip>


### PR DESCRIPTION
上部のトラック選択について、HtmlTooltipでwrapしたことでButtonGroupが自動でselected扱いにしてくれなくなりデグレっていたので、明示的にselectedにするように修正しました