### PR TITLE
Reduce api call on live talk update

### DIFF
--- a/src/components/Track/Track.tsx
+++ b/src/components/Track/Track.tsx
@@ -45,7 +45,7 @@ export const TrackView: React.FC<Props> = ({ event, refetch }) => {
   useKarteTracking()
   useTrailMapTracking()
   useLiveTalkUpdate(event.abbr, () => {
-    refetch() // onAirの切り替わった新しいTalk一覧を取得
+    // refetch() // onAirの切り替わった新しいTalk一覧を取得
   })
   const isSmallerThanMd = useSizeChecker()
 

--- a/src/components/TrackSelector/hooks.ts
+++ b/src/components/TrackSelector/hooks.ts
@@ -7,6 +7,7 @@ import {
   settingsSelector,
   liveTalkUpdate,
   isLiveModeSelector,
+  patchTalksOnAir,
 } from '../../store/settings'
 import { useMediaQuery, useTheme } from '@material-ui/core'
 import { getSlotId } from '../../util/sessionstorage/trailMap'
@@ -116,9 +117,10 @@ export const useLiveTalkUpdate = (eventAbbr: string, fn: () => void) => {
     cable.subscriptions.create(
       { channel: 'OnAirChannel', eventAbbr: eventAbbr },
       {
-        received: (nextTalk: { [trackId: number]: Talk }) => {
+        received: (nextTalks: { [trackId: number]: Talk }) => {
           fn()
-          dispatch(liveTalkUpdate(nextTalk))
+          dispatch(liveTalkUpdate(nextTalks))
+          dispatch(patchTalksOnAir(nextTalks))
         },
       },
     )

--- a/src/components/TrackSelector/hooks.ts
+++ b/src/components/TrackSelector/hooks.ts
@@ -5,7 +5,7 @@ import {
   useSelectedTrack,
   settingsInitializedSelector,
   settingsSelector,
-  liveTalkUpdate,
+  updateViewTalkWithLiveOne,
   isLiveModeSelector,
   patchTalksOnAir,
 } from '../../store/settings'
@@ -119,7 +119,7 @@ export const useLiveTalkUpdate = (eventAbbr: string, fn: () => void) => {
       {
         received: (nextTalks: { [trackId: number]: Talk }) => {
           fn()
-          dispatch(liveTalkUpdate(nextTalks))
+          dispatch(updateViewTalkWithLiveOne(nextTalks))
           dispatch(patchTalksOnAir(nextTalks))
         },
       },

--- a/src/components/hooks/__tests__/useRunAfter.spec.tsx
+++ b/src/components/hooks/__tests__/useRunAfter.spec.tsx
@@ -1,0 +1,29 @@
+import React, { useEffect, useState } from 'react'
+import { useRunAfter } from '../useRunAfter'
+import { render } from '@testing-library/react'
+
+describe('useRunAfter', () => {
+  it('should run callback after specified delay and skip calls in the middle', async () => {
+    const fn = jest.fn()
+    let trials = 0
+    const Test = () => {
+      const { run } = useRunAfter(fn, 30)
+      const [tick, setTick] = useState<number>(0)
+      useEffect(() => {
+        setTimeout(() => setTick(tick + 1), 10)
+      }, [tick])
+      useEffect(() => {
+        trials++
+        run()
+      }, [tick])
+      return tick > 8 ? <div data-testid={'tgt'} /> : <div></div>
+    }
+
+    const screen = render(<Test />)
+    await screen.findByTestId('tgt')
+
+    expect(trials).toBeGreaterThan(8)
+    expect(fn.mock.calls.length).toBeGreaterThan(1)
+    expect(fn.mock.calls.length).toBeLessThan(4)
+  })
+})

--- a/src/components/hooks/useRunAfter.ts
+++ b/src/components/hooks/useRunAfter.ts
@@ -1,0 +1,20 @@
+import { useCallback, useState } from 'react'
+
+export const useRunAfter = (fn: () => void, after: number) => {
+  const [cancel, setCancel] = useState<NodeJS.Timeout | null>()
+
+  const run = useCallback(() => {
+    if (cancel) {
+      return
+    }
+    const c = setTimeout(() => {
+      fn()
+      setCancel(null)
+    }, after)
+    setCancel(c)
+  }, [cancel, setCancel])
+
+  return {
+    run,
+  }
+}

--- a/src/pages/[eventAbbr]/ui/index.tsx
+++ b/src/pages/[eventAbbr]/ui/index.tsx
@@ -23,6 +23,8 @@ const IndexMain = () => {
   const { eventAbbr } = useRouterQuery()
   const { event } = useInitSetup(eventAbbr)
   const { refetch } = useGetTalksAndTracks()
+
+  // NOTE: TrailMapが不要になったら、以下の3つとpointEventSavingのガードをコメントアウトすればよい
   usePostPointEvent()
   usePostSessionPointEvent()
   useAppDataSetup()

--- a/src/store/__tests__/settings.spec.tsx
+++ b/src/store/__tests__/settings.spec.tsx
@@ -1,7 +1,7 @@
 import React from 'react'
 import { renderWithProviders, setupStore } from '../../testhelper/store'
 import {
-  liveTalkUpdate,
+  updateViewTalkWithLiveOne,
   setInitialViewTalk,
   setIsLiveMode,
   setTalks,
@@ -471,7 +471,7 @@ describe('action:setInitialViewTalk', () => {
   })
 })
 
-describe('action:liveTalkUpdate', () => {
+describe('action:updateViewTalkWithLiveOne', () => {
   it('should set next talkId', () => {
     const store = setupStore()
     store.dispatch(setTalks(MockTalks()))
@@ -483,7 +483,7 @@ describe('action:liveTalkUpdate', () => {
     const nextTalks = {
       [MockTrackA().id]: MockTalkA2(),
     }
-    store.dispatch(liveTalkUpdate(nextTalks))
+    store.dispatch(updateViewTalkWithLiveOne(nextTalks))
 
     const got = {
       viewTalkId: store.getState().settings.viewTalkId,
@@ -505,7 +505,7 @@ describe('action:liveTalkUpdate', () => {
     const nextTalks = {
       [MockTrackA().id]: MockTalkA2(),
     }
-    store.dispatch(liveTalkUpdate(nextTalks))
+    store.dispatch(updateViewTalkWithLiveOne(nextTalks))
 
     const got = {
       viewTalkId: store.getState().settings.viewTalkId,
@@ -526,7 +526,7 @@ describe('action:liveTalkUpdate', () => {
     const nextTalks = {
       [MockTrackA().id]: MockTalkA2(),
     }
-    store.dispatch(liveTalkUpdate(nextTalks))
+    store.dispatch(updateViewTalkWithLiveOne(nextTalks))
 
     const got = {
       viewTalkId: store.getState().settings.viewTalkId,

--- a/src/store/settings.ts
+++ b/src/store/settings.ts
@@ -173,7 +173,7 @@ const settingsSlice = createSlice({
         }
       })
     },
-    liveTalkUpdate: (
+    updateViewTalkWithLiveOne: (
       s,
       action: PayloadAction<{ [trackId: number]: Talk }>,
     ) => {
@@ -267,7 +267,7 @@ export const {
   setInitialViewTalk,
   setIsLiveMode,
   patchTalksOnAir,
-  liveTalkUpdate,
+  updateViewTalkWithLiveOne,
 } = settingsSlice.actions
 
 export const settingsSelector = (s: RootState) => s.settings

--- a/src/store/settings.ts
+++ b/src/store/settings.ts
@@ -23,7 +23,7 @@ type ConfDay = {
   internal?: boolean | undefined
 }
 
-type OnAirTalk = {
+export type OnAirTalk = {
   talk_id: number
   [k: string]: any
 }
@@ -152,6 +152,7 @@ const settingsSlice = createSlice({
       s.tracks.forEach((t) => {
         const nextTalk = nextTalks[t.id]
         if (!nextTalk) {
+          t.onAirTalk = null
           return
         }
         // Track.onAirTalk内のtalk_id以外の値は使っていない（openapiにも型定義がなく、極力依存すべきでない）


### PR DESCRIPTION
現状、Live talk更新のaction cableイベントが発火されたときに、全クライアントが一斉にtalk/trackのfetchを行う実装となっており、負荷増が懸念されることから、talk/trackの最新化のAPI callを減らすとともに、タイミングをばらつかせることで負荷を平準化しました。

live talkの更新はaction cableから渡されるデータだけを用いて行います。
talk/trackの最新化は、複数trackのうちはじめにlive talkの切り替わりが発生してから5分程度（厳密には270s〜330sの中のランダムな値）経過した後に1回だけ行うようにしました。