### PR TITLE
fix: show loading skeleton during stamp saving

### DIFF
--- a/src/components/TrailMap/hooks.ts
+++ b/src/components/TrailMap/hooks.ts
@@ -63,6 +63,7 @@ export const useAddStampIfSatisfied = () => {
 
   const [addedByQRCode, setAddedByQRCode] = useState<boolean>(false)
   const [addedNew, setAddedNew] = useState<boolean>(false)
+  const [loading, setLoading] = useState<boolean>(false)
   const [mutateAppData] =
     usePostApiV1AppDataByProfileIdConferenceAndConferenceMutation()
   const [postPointEvent] = usePostApiV1ProfileByProfileIdPointMutation()
@@ -90,6 +91,7 @@ export const useAddStampIfSatisfied = () => {
       }
       const eventNum = getSessionEventNum(slotIdToBeStamped)
       const pointEventId = getPointEventId(eventNum)
+      setLoading(true)
       try {
         await postPointEvent({
           profileId: `${settings.profile.id}`,
@@ -111,11 +113,14 @@ export const useAddStampIfSatisfied = () => {
         setAddedNew(true)
       } catch (err) {
         console.error('stampFromUI Action', err)
+      } finally {
+        setLoading(false)
       }
     })()
   }, [initialized, canGetNewStamp])
 
   return {
+    loading,
     addedNew,
     addedByQRCode,
   }

--- a/src/components/TrailMap/internal/StampCard.tsx
+++ b/src/components/TrailMap/internal/StampCard.tsx
@@ -14,7 +14,7 @@ const imgStamp = `/cicd2023/ui/cicd2023_stamp.png`
 export const StampCard = () => {
   const { appDataInitialized } = useSelector(appDataSelector)
   const { stamps } = useStamps()
-  const { addedNew, addedByQRCode } = useAddStampIfSatisfied()
+  const { loading, addedNew, addedByQRCode } = useAddStampIfSatisfied()
 
   const [pinnedStamps, setPinnedStamps] = useState<
     DkUiData['stampChallenges'] | null
@@ -33,7 +33,7 @@ export const StampCard = () => {
   useImgPreload(imgStampBg)
   useImgPreload(imgStamp)
 
-  if (!pinnedStamps) {
+  if (!pinnedStamps || loading) {
     return (
       <Styled.StampCardContainer>
         <div className={'suspend'}>


### PR DESCRIPTION
オンラインユーザが条件を満たしてTrailMapモーダルを開いてスタンプを獲得した際に、pointEventを永続化している最中に画面の動きがなくて止まっているみたいに見えるので、skeletonを表示するようにしました。