### PR TITLE
fix: Prevent blocking dashboard-page rendering when session-point QR code loaded but there are no live talk

### DIFF
--- a/src/components/hooks/usePostSessionPointEvent.ts
+++ b/src/components/hooks/usePostSessionPointEvent.ts
@@ -79,6 +79,8 @@ export const usePostSessionPointEvent = () => {
 
     if (!track?.onAirTalk) {
       console.warn('no onAir talk')
+      clearSessionPointEventId()
+      dispatch(setPointEventSaving(false))
       return
     }
     setTrackId(track.id)


### PR DESCRIPTION
live talkが始まってない状態でセッション視聴によるスタンプ取得のQRコードを読み込むと、デッドロックになってしまう事象がでました。この状態になると、ローディングのグルグル画面が表示されたままdk-uiにアクセスできなくなります。
ユーザがこの事象にハマることは原則ありえないですが、スタッフはこのケースにハマることがありえてしまい、かつこうなるとsession storageのデータを消すしか対処がなくなるので、デッドロックにならないように修正しました。

やったことは、onAir talkがない分岐のところで、ただfail fastさせるだけではなく、loading画面のrenderingの解消とsession storageの破棄をする、という処理を追加しただけです。