### PR TITLE
fix: Not to call refetch when initial query not completed

### DIFF
--- a/src/components/hooks/useGetTalksAndTracks.ts
+++ b/src/components/hooks/useGetTalksAndTracks.ts
@@ -18,6 +18,9 @@ export const useGetTalksAndTracks = () => {
   const [isDoneFirstQuery, setDoneFirstQuery] = useState<boolean>(false)
 
   const refetch = useCallback(() => {
+    if (!isDoneFirstQuery) {
+      return
+    }
     talksQuery.refetch()
     tracksQuery.refetch()
   }, [talksQuery.refetch, tracksQuery.refetch])


### PR DESCRIPTION
事前登録セッションを表示したあと、メイン画面に戻ると、通常のfetchの前にrefetchが実行されてしまう結果エラーになり、真っ白な画面が表示される事象が出ていたので、その対処です。