### PR TITLE
fix: not to show now-archiving when intersection slot and talks not started yet

### DIFF
--- a/src/components/IvsPlayer/IvsPlayer.tsx
+++ b/src/components/IvsPlayer/IvsPlayer.tsx
@@ -26,6 +26,24 @@ export const IvsPlayer: React.FC<Props> = ({
         </Styled.OverLayContainer>
       )
     }
+    if (videoCommand.status === 'notStarted') {
+      return (
+        <Styled.OverLayContainer>
+          <Styled.TextContainer>
+            <p>セッションの開始まで、しばらくお待ち下さい。</p>
+          </Styled.TextContainer>
+        </Styled.OverLayContainer>
+      )
+    }
+    if (videoCommand.status === 'done') {
+      return (
+        <Styled.OverLayContainer>
+          <Styled.TextContainer>
+            <p>セッションは終了しました。</p>
+          </Styled.TextContainer>
+        </Styled.OverLayContainer>
+      )
+    }
     if (videoCommand.status === 'preparing') {
       return (
         <Styled.OverLayContainer>
@@ -40,8 +58,8 @@ export const IvsPlayer: React.FC<Props> = ({
       return (
         <Styled.OverLayContainer>
           <Styled.TextContainer>
-            <p>アーカイブ中です。</p>
-            <p>完了までお待ちください。</p>
+            <p>セッションは終了しました。</p>
+            <p>アーカイブ完了までお待ちください。</p>
           </Styled.TextContainer>
         </Styled.OverLayContainer>
       )

--- a/src/components/IvsPlayer/__tests__/__snapshots__/IvsPlayer.spec.tsx.snap
+++ b/src/components/IvsPlayer/__tests__/__snapshots__/IvsPlayer.spec.tsx.snap
@@ -16,10 +16,10 @@ exports[`IvsPlayer should render archiving page 1`] = `
             class="styled__TextContainer-sc-1l56t7n-5 ctYScI"
           >
             <p>
-              アーカイブ中です。
+              セッションは終了しました。
             </p>
             <p>
-              完了までお待ちください。
+              アーカイブ完了までお待ちください。
             </p>
           </div>
         </div>

--- a/src/store/__tests__/settings.spec.tsx
+++ b/src/store/__tests__/settings.spec.tsx
@@ -31,6 +31,16 @@ import {
 import { useSelector } from 'react-redux'
 import { Talk } from '../../generated/dreamkast-api.generated'
 
+const archive = (t: Talk) => {
+  t.onAir = false
+  return t
+}
+
+const onAir = (t: Talk) => {
+  t.onAir = true
+  return t
+}
+
 describe('useTracks', () => {
   it('should provide tracks along with corresponding live talk', () => {
     let got: any = null
@@ -286,7 +296,27 @@ describe('selector:videoCommandSelector', () => {
 
   it('should provide the videoId of the talk when selected talk is not live', () => {
     let got = {} as unknown
-    const want = newVideoCommand('archived', MockTalkA3().videoId)
+    const want = newVideoCommand('notStarted')
+
+    const Test = () => {
+      got = useSelector(videoCommandSelector)
+      return <div />
+    }
+
+    const store = setupStore()
+    const mockTalks = [archive(MockTalkA1()), MockTalkA2(), onAir(MockTalkA3())]
+    store.dispatch(setTracks(MockTracks()))
+    store.dispatch(setTalks(mockTalks))
+    store.dispatch(setViewTrackId(MockTrackA().id))
+    store.dispatch(setViewTalkId(MockTalkA1().id))
+    renderWithProviders(<Test />, { store })
+
+    expect(got).toStrictEqual(want)
+  })
+
+  it('should provide empty string when selected talk is placed after the onAir talk', () => {
+    let got = {} as unknown
+    const want = newVideoCommand('notStarted')
 
     const Test = () => {
       got = useSelector(videoCommandSelector)
@@ -375,16 +405,6 @@ describe('selector:videoCommandSelector', () => {
 })
 
 describe('action:setInitialViewTalk', () => {
-  const archive = (t: Talk) => {
-    t.onAir = false
-    return t
-  }
-
-  const onAir = (t: Talk) => {
-    t.onAir = true
-    return t
-  }
-
   it('should set the first track as viewing Track', () => {
     const store = setupStore()
     store.dispatch(setTracks(MockTracks()))
@@ -546,11 +566,6 @@ describe('action:patchTalksOnAir', () => {
     const store = setupStore()
     store.dispatch(setTalks(MockTalks()))
     store.dispatch(setTracks(MockTracks()))
-
-    const onAir = (t: Talk) => {
-      t.onAir = true
-      return t
-    }
 
     const nextTalks = {
       [MockTrackA().id]: onAir(MockTalkA2()),

--- a/src/store/__tests__/settings.spec.tsx
+++ b/src/store/__tests__/settings.spec.tsx
@@ -296,7 +296,7 @@ describe('selector:videoCommandSelector', () => {
 
   it('should provide the videoId of the talk when selected talk is not live', () => {
     let got = {} as unknown
-    const want = newVideoCommand('notStarted')
+    const want = newVideoCommand('archived', MockTalkA1().videoId)
 
     const Test = () => {
       got = useSelector(videoCommandSelector)
@@ -314,7 +314,27 @@ describe('selector:videoCommandSelector', () => {
     expect(got).toStrictEqual(want)
   })
 
-  it('should provide empty string when selected talk is placed after the onAir talk', () => {
+  it('should provide archiving status when selected talk is placed before the onAir talk but no videoId provided', () => {
+    let got = {} as unknown
+    const want = newVideoCommand('archiving')
+
+    const Test = () => {
+      got = useSelector(videoCommandSelector)
+      return <div />
+    }
+
+    const store = setupStore()
+    const mockTalks = [archive(MockTalkA1()), MockTalkA2(), onAir(MockTalkA3())]
+    store.dispatch(setTracks(MockTracks()))
+    store.dispatch(setTalks(mockTalks))
+    store.dispatch(setViewTrackId(MockTrackA().id))
+    store.dispatch(setViewTalkId(MockTalkA2().id))
+    renderWithProviders(<Test />, { store })
+
+    expect(got).toStrictEqual(want)
+  })
+
+  it('should provide notStarted status when selected talk is placed after the onAir talk', () => {
     let got = {} as unknown
     const want = newVideoCommand('notStarted')
 

--- a/src/store/settings.ts
+++ b/src/store/settings.ts
@@ -373,7 +373,14 @@ export const settingsInitializedSelector = createSelector(
 )
 
 export type VideoCommand = {
-  status: 'preparing' | 'onAir' | 'archiving' | 'archived' | 'notSelected'
+  status:
+    | 'preparing'
+    | 'onAir'
+    | 'archiving'
+    | 'archived'
+    | 'notSelected'
+    | 'notStarted'
+    | 'done'
   playBackUrl?: string
 }
 
@@ -407,12 +414,23 @@ export const videoCommandSelector = createSelector(
         return newVideoCommand('preparing')
       }
       return newVideoCommand('onAir', selectedTrack.videoId)
-    } else {
-      if (!selectedTalk.videoId) {
-        return newVideoCommand('archiving')
-      }
-      return newVideoCommand('archived', selectedTalk.videoId)
     }
+
+    const onAirTalk = talks.find((t) => t.trackId === viewTrackId && t.onAir)
+    if (onAirTalk && onAirTalk.slotNum! <= selectedTalk.slotNum!) {
+      return newVideoCommand('notStarted')
+    }
+    // okui:
+    // TODO showOnTimeTableの方が適切なので、そっちに変更する。
+    // CICD2023では、リハーサルでshowOnTimeTableが正しく入っておらず検証ができなかったので、暫定でpresentationMethodを使う
+    if (!selectedTalk.presentationMethod) {
+      // intersection
+      return newVideoCommand('done')
+    }
+    if (!selectedTalk.videoId) {
+      return newVideoCommand('archiving')
+    }
+    return newVideoCommand('archived', selectedTalk.videoId)
   },
 )
 

--- a/src/testhelper/fixture.ts
+++ b/src/testhelper/fixture.ts
@@ -53,7 +53,7 @@ export const MockTalkA1 = () =>
     actualStartTime: '2000-01-01T10:00:00.000+09:00',
     actualEndTime: '2000-01-01T10:20:00.000+09:00',
     presentationMethod: '現地登壇',
-    slotNum: 0,
+    slotNum: 1101,
   })
 
 export const MockTalkA2 = () =>
@@ -83,7 +83,7 @@ export const MockTalkA2 = () =>
     actualStartTime: '2000-01-01T10:25:00.000+09:00',
     actualEndTime: '2000-01-01T10:45:00.000+09:00',
     presentationMethod: 'オンライン登壇',
-    slotNum: 0,
+    slotNum: 1102,
   })
 
 export const MockTalkA3 = () =>
@@ -113,7 +113,7 @@ export const MockTalkA3 = () =>
     actualStartTime: '2000-01-01T10:50:00.000+09:00',
     actualEndTime: '2000-01-01T11:10:00.000+09:00',
     presentationMethod: '事前収録',
-    slotNum: 0,
+    slotNum: 1103,
   })
 
 export const MockTalkB1 = () =>
@@ -146,7 +146,7 @@ export const MockTalkB1 = () =>
     actualStartTime: '2000-01-01T13:20:00.000+09:00',
     actualEndTime: '2000-01-01T14:00:00.000+09:00',
     presentationMethod: null,
-    slotNum: 2,
+    slotNum: 1101,
   })
 
 export const MockTalkC1 = () =>
@@ -182,7 +182,7 @@ export const MockTalkC1 = () =>
     actualStartTime: '2000-01-01T13:20:00.000+09:00',
     actualEndTime: '2000-01-01T14:00:00.000+09:00',
     presentationMethod: null,
-    slotNum: 2,
+    slotNum: 1101,
   })
 
 export const MockTrackA = () =>


### PR DESCRIPTION
not onAir && not videoIdなtalkに対してアーカイブ画面を表示したら、以下の問題がでたので、対処しました。
- オープニングや休憩なども「アーカイブ完了まで〜〜」という表示が出てしまう
- まだ開始していないtalkでも「アーカイブ完了まで〜〜」という表示が出てしまう

それぞれ、まだ未開始のtalkを選択できてしまった場合は「開始までお待ち下さい」、完了した休憩スロットには「セッションは終了しました」とだけ表示するようにしました。