### PR TITLE
fix: Real-time update available talks on TalkSelector

### DIFF
--- a/src/components/TalkSelector/TalkSelector.tsx
+++ b/src/components/TalkSelector/TalkSelector.tsx
@@ -24,7 +24,7 @@ export const TalkSelector: React.FC<Props> = (props) => {
     const id = window.setInterval(() => {
       setNow(dayjs().unix())
     }, 1000)
-    return window.clearInterval(id)
+    return () => window.clearInterval(id)
   }, [])
 
   const footer = (


### PR DESCRIPTION
TalkSelectorの時刻更新において、functionをreturnするのではなく即時実行されており、結果としてcomponent destroy時ではなくすぐにsetIntervalがstopされて、時間の更新がされなくなっていました。その修正です。