### PR TITLE
fix: Address issue-452

### DIFF
--- a/src/components/Menu/DesktopMenu.tsx
+++ b/src/components/Menu/DesktopMenu.tsx
@@ -16,7 +16,7 @@ type Props = {
 export const DesktopMenu: React.FC<Props> = ({ event }) => {
   const { logout } = useAuth0()
   const { dkUrl } = useSelector(authSelector)
-  const { guideUrl, isPreEvent } = useMenuContents()
+  const { guideUrl, isPreEvent } = useMenuContents(event?.abbr)
 
   return (
     <Styled.DesktopMenu>
@@ -48,7 +48,8 @@ export const DesktopMenu: React.FC<Props> = ({ event }) => {
       </CommonStyled.MenuLink>
       <CommonStyled.MenuLink
         href={`/${event?.abbr}/timetables`}
-        rel="noreferrer"
+        target="_blank"
+        rel="noreferrer noopener"
       >
         <Button style={{ color: '#423A57' }}>Timetable</Button>
       </CommonStyled.MenuLink>

--- a/src/components/Menu/MobileMenu.tsx
+++ b/src/components/Menu/MobileMenu.tsx
@@ -22,7 +22,7 @@ type Props = {
 export const MobileMenu: React.FC<Props> = ({ event }) => {
   const { logout } = useAuth0()
   const { dkUrl } = useSelector(authSelector)
-  const { guideUrl, isPreEvent } = useMenuContents()
+  const { guideUrl, isPreEvent } = useMenuContents(event?.abbr)
   const [state, setState] = React.useState(false)
   const toggleDrawer =
     (open: boolean) => (event: React.KeyboardEvent | React.MouseEvent) => {

--- a/src/components/Menu/hooks.ts
+++ b/src/components/Menu/hooks.ts
@@ -1,13 +1,13 @@
 import { useSelector } from 'react-redux'
 import { settingsSelector } from '../../store/settings'
 
-export const useMenuContents = () => {
+export const useMenuContents = (eventAbbr: string | undefined) => {
   const settings = useSelector(settingsSelector)
   const guideUrl = (): string => {
     if (settings.profile.isAttendOffline) {
-      return 'https://sites.google.com/view/cicd2023/現地参加オフライン'
+      return `https://sites.google.com/view/${eventAbbr}/現地参加オフライン`
     } else {
-      return 'https://sites.google.com/view/cicd2023/オンライン参加'
+      return `https://sites.google.com/view/${eventAbbr}/オンライン参加`
     }
   }
   const isPreEvent = settings.conferenceDay?.internal

--- a/src/pages/[eventAbbr]/ui/index.tsx
+++ b/src/pages/[eventAbbr]/ui/index.tsx
@@ -8,6 +8,7 @@ import { useGetTalksAndTracks } from '../../../components/hooks/useGetTalksAndTr
 import { useRouterQuery } from '../../../components/hooks/useRouterQuery'
 import { withAuthProvider } from '../../../context/auth'
 import { NextTalkNotifier } from '../../../components/Layout/NextTalkNotifier'
+import { ENV } from '../../../config'
 
 const IndexPage: NextPage = () => {
   return withAuthProvider(<IndexMain />)
@@ -46,6 +47,15 @@ const IndexMain = () => {
       </Layout>
     </NextTalkNotifier>
   )
+}
+
+// TODO move to RootApp component
+export const getServerSideProps = async () => {
+  return {
+    props: {
+      env: { ...ENV },
+    },
+  }
 }
 
 export default IndexPage

--- a/src/pages/[eventAbbr]/ui/info/index.tsx
+++ b/src/pages/[eventAbbr]/ui/info/index.tsx
@@ -10,6 +10,7 @@ import { useDispatch } from 'react-redux'
 import { Layout } from '../../../../components/Layout'
 import { RegisteredTalks } from '../../../../components/RegisteredTalks'
 import { Typography } from '@material-ui/core'
+import { ENV } from '../../../../config'
 
 const IndexPage: NextPage = () => {
   const router = useRouter()
@@ -45,6 +46,15 @@ const IndexPage: NextPage = () => {
     )
   } else {
     return <div></div>
+  }
+}
+
+// TODO move to RootApp component
+export const getServerSideProps = async () => {
+  return {
+    props: {
+      env: { ...ENV },
+    },
   }
 }
 

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -75,7 +75,7 @@ const RootApp = ({ Component, pageProps, env }: RootAppProps) => {
   }, [])
 
   const client = new ApolloClient({
-    uri: env.NEXT_PUBLIC_WEAVER_URL + 'query',
+    uri: (new URL('query', env.NEXT_PUBLIC_WEAVER_URL)).href,
     cache: new InMemoryCache(),
   })
 

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -75,7 +75,7 @@ const RootApp = ({ Component, pageProps, env }: RootAppProps) => {
   }, [])
 
   const client = new ApolloClient({
-    uri: (new URL('query', env.NEXT_PUBLIC_WEAVER_URL)).href,
+    uri: new URL('query', env.NEXT_PUBLIC_WEAVER_URL).href,
     cache: new InMemoryCache(),
   })
 


### PR DESCRIPTION
https://github.com/cloudnativedaysjp/dreamkast-ui/issues/452 に対処しました。

`/ui/info からtimetableに行って、戻ると /info にredirectされてしまう` の件は抜本対処はしていませんが、とりあえず別タブで開くことで発生を抑止できるので、それで対処とさせてください。