### PR TITLE
feat: Rehearsal view

### DIFF
--- a/schemas/swagger.yml
+++ b/schemas/swagger.yml
@@ -961,6 +961,8 @@ components:
           type: string
         status:
           type: string
+        rehearsalMode:
+          type: boolean
         theme:
           type: string
         about:

--- a/src/components/Layout/Layout.tsx
+++ b/src/components/Layout/Layout.tsx
@@ -30,7 +30,7 @@ export const Layout: React.FC<Props> = ({
       </Head>
       <header>
         <AppBar position="static">
-          <Styled.Header>
+          <Styled.Header isRehearsal={event?.rehearsalMode}>
             <Link href={`/${event?.abbr}/ui`} rel="noopener noreferrer">
               <Styled.HeaderImg
                 src={`/${event?.abbr}/ui/${event?.abbr}_header_logo.png`}

--- a/src/components/Layout/styled.ts
+++ b/src/components/Layout/styled.ts
@@ -11,10 +11,10 @@ export const Container = styled.div<{ eventAbbr?: string }>`
   min-height: 100vh;
 `
 
-export const Header = styled(Toolbar)`
+export const Header = styled(Toolbar)<{ isRehearsal?: boolean }>`
   display: flex;
   justify-content: flex-start;
-  background-color: #ffffff;
+  background-color: ${(props) => (props.isRehearsal ? '#ffeb3b' : '#ffffff')};
   color: #282828;
 `
 

--- a/src/components/TalkSelector/TalkSelector.tsx
+++ b/src/components/TalkSelector/TalkSelector.tsx
@@ -98,7 +98,7 @@ type TalkWithAvailable = Talk & {
 export const extractAvailableTalks = (
   talks: Talk[],
   now: number,
-  isRehearsal: boolean = false,
+  isRehearsal = false,
 ): TalkWithAvailable[] => {
   return [...talks]
     .sort((n1, n2) => dayjs(n1.startTime).unix() - dayjs(n2.startTime).unix())
@@ -106,7 +106,9 @@ export const extractAvailableTalks = (
     .map((talk) => {
       return {
         ...talk,
-        available: isRehearsal ? true : isAvailable(now, talk.startTime, talk.conferenceDayDate),
+        available: isRehearsal
+          ? true
+          : isAvailable(now, talk.startTime, talk.conferenceDayDate),
       }
     })
 }

--- a/src/components/TalkSelector/TalkSelector.tsx
+++ b/src/components/TalkSelector/TalkSelector.tsx
@@ -14,6 +14,7 @@ type Props = {
   talks: Talk[]
   selectTalk: (talkId: number) => void
   small?: boolean
+  isRehearsal?: boolean
 }
 
 export const TalkSelector: React.FC<Props> = (props) => {
@@ -50,11 +51,12 @@ export const PTalkSelector: React.FC<PProps> = ({
   talks,
   selectTalk,
   small = false,
+  isRehearsal = false,
   now,
   footer,
 }) => {
   const availableTalks = useMemo(
-    () => extractAvailableTalks(talks, now),
+    () => extractAvailableTalks(talks, now, isRehearsal),
     [talks, now],
   )
 
@@ -96,6 +98,7 @@ type TalkWithAvailable = Talk & {
 export const extractAvailableTalks = (
   talks: Talk[],
   now: number,
+  isRehearsal: boolean = false,
 ): TalkWithAvailable[] => {
   return [...talks]
     .sort((n1, n2) => dayjs(n1.startTime).unix() - dayjs(n2.startTime).unix())
@@ -103,7 +106,7 @@ export const extractAvailableTalks = (
     .map((talk) => {
       return {
         ...talk,
-        available: isAvailable(now, talk.startTime, talk.conferenceDayDate),
+        available: isRehearsal ? true : isAvailable(now, talk.startTime, talk.conferenceDayDate),
       }
     })
 }

--- a/src/components/TalkSelector/__tests__/TalkSelector.spec.tsx
+++ b/src/components/TalkSelector/__tests__/TalkSelector.spec.tsx
@@ -50,6 +50,20 @@ describe('PTalkSelector', () => {
     )
     expect(screen.asFragment()).toMatchSnapshot()
   })
+  it('should render without crash when rehearsal mode', () => {
+    const now = dayjs('2023-02-24T10:30:00.000+09:00').unix()
+    const screen = render(
+      <PTalkSelector
+        selectedTalkId={MockTalks()[0].id}
+        selectedTrackId={32}
+        talks={MockTalks()}
+        selectTalk={() => null}
+        now={now}
+        isRehearsal={true}
+      />,
+    )
+    expect(screen.asFragment()).toMatchSnapshot()
+  })
   it('should render when props undefined', () => {
     const now = dayjs('2023-02-24T10:30:00.000+09:00').unix()
     const screen = render(

--- a/src/components/TalkSelector/__tests__/__snapshots__/TalkSelector.spec.tsx.snap
+++ b/src/components/TalkSelector/__tests__/__snapshots__/TalkSelector.spec.tsx.snap
@@ -95,3 +95,81 @@ exports[`PTalkSelector should render without crash 1`] = `
   </div>
 </DocumentFragment>
 `;
+
+exports[`PTalkSelector should render without crash when rehearsal mode 1`] = `
+<DocumentFragment>
+  <div
+    class="styled__Container-sc-1piihja-0"
+  >
+    <div
+      class="styled__Title-sc-1piihja-1 dCJJhl"
+    >
+      このトラックのセッション
+    </div>
+    <ul
+      class="MuiList-root styled__List-sc-1piihja-2 ekPnFm MuiList-padding"
+      height="497"
+    >
+      <div
+        aria-disabled="false"
+        class="MuiButtonBase-root MuiListItem-root styled__Item-sc-1piihja-3 dLdJEz MuiListItem-gutters MuiListItem-button Mui-selected"
+        role="button"
+        tabindex="0"
+      >
+        <div
+          class="styled__Text-sc-1piihja-4 bBebjD"
+        >
+          <span
+            class="styled__Live-sc-1piihja-5 cUVkFS"
+          >
+            LIVE
+          </span>
+           10:00-10:20
+          <br />
+          Securityに関する発表
+        </div>
+        <span
+          class="MuiTouchRipple-root"
+        />
+      </div>
+      <div
+        aria-disabled="false"
+        class="MuiButtonBase-root MuiListItem-root styled__Item-sc-1piihja-3 gUnfTx MuiListItem-gutters MuiListItem-button"
+        role="button"
+        tabindex="0"
+      >
+        <div
+          class="styled__Text-sc-1piihja-4 bBebjD"
+        >
+           10:25-10:45
+          <br />
+          IoT/Edgeに関する10の知見
+        </div>
+        <span
+          class="MuiTouchRipple-root"
+        />
+      </div>
+      <div
+        aria-disabled="false"
+        class="MuiButtonBase-root MuiListItem-root styled__Item-sc-1piihja-3 gUnfTx MuiListItem-gutters MuiListItem-button"
+        role="button"
+        tabindex="0"
+      >
+        <div
+          class="styled__Text-sc-1piihja-4 bBebjD"
+        >
+           10:50-11:10
+          <br />
+          CloudNative Networking
+        </div>
+        <span
+          class="MuiTouchRipple-root"
+        />
+      </div>
+    </ul>
+    <div
+      class="styled__Footer-sc-1piihja-6 hlpNiv"
+    />
+  </div>
+</DocumentFragment>
+`;

--- a/src/components/Track/Track.tsx
+++ b/src/components/Track/Track.tsx
@@ -107,6 +107,7 @@ export const TrackView: React.FC<Props> = ({ event, refetch }) => {
             talks={talks}
             selectTalk={selectTalk}
             small
+            isRehearsal={event.rehearsalMode}
           />
         </Grid>
       </Grid>

--- a/src/generated/dreamkast-api.generated.ts
+++ b/src/generated/dreamkast-api.generated.ts
@@ -451,6 +451,7 @@ export type Event = {
   name: string
   abbr: string
   status: string
+  rehearsalMode?: boolean | undefined
   theme: string
   about: string
   privacy_policy: string

--- a/src/store/settings.ts
+++ b/src/store/settings.ts
@@ -95,9 +95,17 @@ const settingsSlice = createSlice({
     setEvent: (state, action: PayloadAction<Event>) => {
       state.event = action.payload
       const today = dayjs(new Date()).tz().format('YYYY-MM-DD')
-      const confDay = action.payload?.conferenceDays?.find(
+      let confDay = action.payload?.conferenceDays?.find(
         (day) => day.date === today,
       )
+      if (!confDay && state.event.rehearsalMode) {
+        console.warn(
+          '### rehearsal mode: fallback to the non-internal confence day',
+        )
+        confDay = (action.payload?.conferenceDays || [])?.find(
+          (conf) => !conf.internal,
+        )
+      }
       if (confDay) {
         state.conferenceDay = {
           id: String(confDay.id),


### PR DESCRIPTION
リハーサル機能を追加しました。
https://github.com/cloudnativedaysjp/dreamkast/pull/2029/files
で追加されたフラグを有効にすると、以下のように挙動が変わります。

- internal=falseのconferenceDay recordを取得し、そのうち1つめの日のtalksを取得します（カンファレンス1日目のレコードになるはずです）
  - なお、明示的にリハを行っている日のinternal=trueのconferenceDayがある場合は、そちらを優先します。同日のconferenceDayを作っていない場合に、上記の挙動になります。
- 現在時刻によらず、任意のtalkを選択できます（対象のtalkが未来時刻であってもdisableされません）
- リハーサルモードであることがわかるように、以下のようにヘッダの色が変わります。

![image](https://github.com/cloudnativedaysjp/dreamkast-ui/assets/19190276/4a95dab0-54a9-4fc0-b1ab-d45f8c3fe9cb)
