### PR TITLE
feat: Restrict access when not opened

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
         "axios": "^1.0.0",
         "dayjs": "^1.11.5",
         "graphql": "^16.6.0",
+        "jwt-decode": "^3.1.2",
         "linkify-react": "^4.0.0",
         "linkifyjs": "^4.0.0",
         "next": "13.4.12",

--- a/src/context/auth.tsx
+++ b/src/context/auth.tsx
@@ -7,9 +7,21 @@ import React, {
 } from 'react'
 import { Auth0Provider, useAuth0 } from '@auth0/auth0-react'
 import { useDispatch, useSelector } from 'react-redux'
-import { setToken, setUser } from '../store/auth'
+import jwtDecode from 'jwt-decode'
+import { setRoles, setToken, setUser } from '../store/auth'
 import { authSelector } from '../store/auth'
 import { PrivateCtx } from './private'
+
+export interface JwtPayload {
+  iss?: string
+  sub?: string
+  aud?: string[] | string
+  exp?: number
+  nbf?: number
+  iat?: number
+  jti?: string
+  'https://cloudnativedays.jp/roles'?: string[]
+}
 
 export const withAuthProvider = (content: ReactNode) => {
   return <AuthProvider>{content}</AuthProvider>
@@ -86,6 +98,11 @@ const useAccessToken = () => {
     }
     getAccessTokenSilently()
       .then((token) => {
+        const decoded = jwtDecode<JwtPayload>(token)
+        const roles = decoded['https://cloudnativedays.jp/roles']
+        if (roles) {
+          dispatch(setRoles(roles))
+        }
         dispatch(setToken(token))
       })
       .catch((err) => {

--- a/src/pages/[eventAbbr]/ui/index.tsx
+++ b/src/pages/[eventAbbr]/ui/index.tsx
@@ -9,6 +9,9 @@ import { useRouterQuery } from '../../../components/hooks/useRouterQuery'
 import { withAuthProvider } from '../../../context/auth'
 import { NextTalkNotifier } from '../../../components/Layout/NextTalkNotifier'
 import { ENV } from '../../../config'
+import { useRouter } from 'next/router'
+import { useSelector } from 'react-redux'
+import { authSelector } from '../../../store/auth'
 
 const IndexPage: NextPage = () => {
   return withAuthProvider(<IndexMain />)
@@ -18,6 +21,8 @@ const IndexMain = () => {
   const { eventAbbr } = useRouterQuery()
   const { event } = useInitSetup(eventAbbr)
   const { refetch } = useGetTalksAndTracks()
+  const { roles, dkUrl } = useSelector(authSelector)
+  const router = useRouter()
 
   // NOTE: TrailMapが必要になったら、以下の3つとpointEventSavingのガードのコメントアウトを解除する
   // TODO: TrailMapを使わない判断がされたら、TrailMap関連の処理を消す
@@ -28,6 +33,14 @@ const IndexMain = () => {
   if (!event) {
     return <></>
   }
+  if (event.status !== 'opened' && roles.length === 0) {
+    console.warn(
+      'Conference has not opened yet. Please access after the conference started.',
+    )
+    router.replace(dkUrl)
+    return
+  }
+
   // const isPointEventSaving = useSelector(pointEventSavingSelector)
   // if (isPointEventSaving) {
   //   return (

--- a/src/store/auth.ts
+++ b/src/store/auth.ts
@@ -5,6 +5,7 @@ import { RootState } from './index'
 type AuthState = {
   user: User | null
   token: string
+  roles: string[]
 
   // TODO move to appropriate redux store
   apiBaseUrl: string
@@ -15,6 +16,7 @@ type AuthState = {
 const initialState: AuthState = {
   user: null,
   token: '',
+  roles: [],
   apiBaseUrl: '',
   wsBaseUrl: '',
   dkUrl: '',
@@ -30,6 +32,9 @@ const authSlice = createSlice({
     setToken: (state, action: PayloadAction<string>) => {
       state.token = action.payload
     },
+    setRoles: (state, action: PayloadAction<string[]>) => {
+      state.roles = action.payload
+    },
     setApiBaseUrl: (state, action: PayloadAction<string>) => {
       state.apiBaseUrl = action.payload
     },
@@ -42,8 +47,14 @@ const authSlice = createSlice({
   },
 })
 
-export const { setUser, setToken, setApiBaseUrl, setWsBaseUrl, setDkUrl } =
-  authSlice.actions
+export const {
+  setUser,
+  setToken,
+  setRoles,
+  setApiBaseUrl,
+  setWsBaseUrl,
+  setDkUrl,
+} = authSlice.actions
 export default authSlice
 
 export const authSelector = (state: RootState) => state.auth

--- a/yarn.lock
+++ b/yarn.lock
@@ -6152,6 +6152,11 @@ jss@10.10.0, jss@^10.5.1:
     object.assign "^4.1.4"
     object.values "^1.1.6"
 
+jwt-decode@^3.1.2:
+  version "3.1.2"
+  resolved "https://registry.yarnpkg.com/jwt-decode/-/jwt-decode-3.1.2.tgz#3fb319f3675a2df0c2895c8f5e9fa4b67b04ed59"
+  integrity sha512-UfpWE/VZn0iP50d8cz9NrZLM9lSWhcJ+0Gt/nm4by88UL+J1SiKN8/5dkjMmbEzwL2CAe+67GsegCbIKtbp75A==
+
 keycode@^2.2.0:
   version "2.2.1"
   resolved "https://registry.yarnpkg.com/keycode/-/keycode-2.2.1.tgz#09c23b2be0611d26117ea2501c2c391a01f39eff"


### PR DESCRIPTION
リハーサル中でも開催前でも、いつでもdk-uiにアクセスできるようになっていますが、opened以外のときはアクセスできないようにしました。
ただし運営はアクセスできるようにしたいので、auth0で何かしらのroleに与えられている人は除外するようにしています（運営に所属している人は、少なくとも1つのroleには属しているであろうと仮定。次のconferenceのadminかを見るとより厳密ですが、がちがちに固めたいわけではないのでこれで十分と判断しました）

気になるのは以下2点です。
- カンファレンス終了後、closedになってもしばらくdk-uiにアクセスできた方が良い？（アーカイブ配信やコメントを見るためにアクセスする人がいる？）
- 運営（特にbroadcastチーム）だけど、auth0で何もroleをアサインされていない人もいる？（その場合は、別の方法で運営を判断する必要があります）