### PR TITLE
fix: Place sponsor logo inside the slick slider container

### DIFF
--- a/src/components/Sponsors/Sponsors.tsx
+++ b/src/components/Sponsors/Sponsors.tsx
@@ -56,7 +56,9 @@ export const Sponsors: React.FC<Props> = ({ event }) => {
         {data.map((sponsor) => (
           <Styled.Sponsor key={sponsor.id}>
             <a href={sponsor.url} target="_blank">
-              <Styled.SponsorImg src={sponsor.logo_url} />
+              <Styled.SponsorImgContainer>
+                <Styled.SponsorImg src={sponsor.logo_url} />
+              </Styled.SponsorImgContainer>
             </a>
           </Styled.Sponsor>
         ))}

--- a/src/components/Sponsors/styled.ts
+++ b/src/components/Sponsors/styled.ts
@@ -3,7 +3,9 @@ import Slider from 'react-slick'
 import 'slick-carousel/slick/slick.css'
 import 'slick-carousel/slick/slick-theme.css'
 
-export const CNDOSlider = styled(Slider)``
+export const CNDOSlider = styled(Slider)`
+  max-height: 54px;
+`
 
 export const Sponsor = styled.div`
   position: relative;

--- a/src/components/Sponsors/styled.ts
+++ b/src/components/Sponsors/styled.ts
@@ -7,16 +7,20 @@ export const CNDOSlider = styled(Slider)``
 
 export const Sponsor = styled.div`
   position: relative;
+  height: 45px;
+`
+
+export const SponsorImgContainer = styled.div`
   height: 40px;
+  width: 100%;
+  position: absolute;
+  top: 10px;
+  display: flex;
 `
 
 export const SponsorImg = styled.img`
   max-width: 150px;
   max-height: 40px;
   margin: auto;
-  position: absolute;
-  top: 0;
-  right: 0;
-  bottom: 0;
-  left: 0;
+  align-items: center;
 `


### PR DESCRIPTION
ロゴがはみ出さないようにしました。
後半になるにつれて若干上に上がっていく事象は解決できていませんが、はみ出しはなくなっています。
（react-slick、挙動がよくわからない。。。）