### PR TITLE
feat: Community LT page

### DIFF
--- a/src/components/TalkInfo/TalkInfoLT.tsx
+++ b/src/components/TalkInfo/TalkInfoLT.tsx
@@ -1,0 +1,30 @@
+import React from 'react'
+import * as Styled from './styled'
+
+type Props = {
+  eventAbbr: string
+  title: string
+  content: string
+}
+
+export const TalkInfoLT: React.FC<Props> = ({ eventAbbr, title, content }) => {
+  const xURL = `http://x.com/share?url=https://event.cloudnativedays.jp/${eventAbbr}&related=@cloudnativedays&hashtags=${eventAbbr}`
+  return (
+    <Styled.Container>
+      <Styled.Title>{title}</Styled.Title>
+      <Styled.Content>{content}</Styled.Content>
+      <Styled.SocialHeader>
+        <Styled.TalkIcon src={`/${eventAbbr}/ui/talk_icon.png`} />
+        一緒に盛り上がろう
+      </Styled.SocialHeader>
+      <Styled.ButtonContainer>
+        <Styled.ButtonLink href={xURL} target="_blank">
+          <Styled.XPostButton>
+            <Styled.XImg src={`/${eventAbbr}/ui/x_logo.png`} />
+            {`ポスト #${eventAbbr}`}
+          </Styled.XPostButton>
+        </Styled.ButtonLink>
+      </Styled.ButtonContainer>
+    </Styled.Container>
+  )
+}

--- a/src/components/TalkInfo/index.tsx
+++ b/src/components/TalkInfo/index.tsx
@@ -1,1 +1,2 @@
 export { TalkInfo } from './TalkInfo'
+export { TalkInfoLT } from './TalkInfoLT'

--- a/src/components/TrackLT/TrackLT.tsx
+++ b/src/components/TrackLT/TrackLT.tsx
@@ -1,0 +1,69 @@
+import React, { useEffect, useRef, useState } from 'react'
+import Grid from '@material-ui/core/Grid'
+import { TalkInfoLT } from '../TalkInfo'
+import { Sponsors } from '../Sponsors'
+import 'dayjs/locale/ja'
+import { Event } from '../../generated/dreamkast-api.generated'
+
+type Props = {
+  event: Event
+  youtubeEmbedLink: string
+  title: string
+  content: string
+}
+
+export const TrackLTView: React.FC<Props> = ({
+  event,
+  youtubeEmbedLink,
+  title,
+  content,
+}) => {
+  const parentRef = useRef<HTMLDivElement>(null)
+  const [size, setSize] = useState({ width: 0, height: 0 })
+
+  const updateDimensions = () => {
+    if (!parentRef.current) {
+      return
+    }
+    const { offsetWidth } = parentRef.current
+    setSize({ width: offsetWidth, height: (offsetWidth * 9) / 16 })
+  }
+
+  useEffect(() => {
+    updateDimensions()
+    let timer: NodeJS.Timeout | number = 0
+    window.addEventListener('resize', () => {
+      clearTimeout(timer)
+      timer = setTimeout(updateDimensions, 200)
+    })
+  }, [])
+
+  return (
+    <Grid container spacing={1} justifyContent="center" alignItems="flex-start">
+      <Grid item xs={12} md={8}>
+        <div ref={parentRef} style={{ width: '100%' }}>
+          <iframe
+            width={`${size.width}`}
+            height={`${size.height}`}
+            src={youtubeEmbedLink}
+            title="YouTube video player"
+            frameBorder="0"
+            allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
+            referrerPolicy="strict-origin-when-cross-origin"
+            allowFullScreen
+          ></iframe>
+        </div>
+        {parentRef.current && (
+          <>
+            <Sponsors event={event} />
+            <TalkInfoLT
+              eventAbbr={event.abbr}
+              title={title}
+              content={content}
+            />
+          </>
+        )}
+      </Grid>
+    </Grid>
+  )
+}

--- a/src/components/TrackLT/index.tsx
+++ b/src/components/TrackLT/index.tsx
@@ -1,0 +1,1 @@
+export { TrackLTView } from './TrackLT'

--- a/src/components/TrackSelector/HtmlTooltip.tsx
+++ b/src/components/TrackSelector/HtmlTooltip.tsx
@@ -1,0 +1,14 @@
+import { Theme, Tooltip } from '@material-ui/core'
+import { withStyles } from '@material-ui/styles'
+
+const HtmlTooltip = withStyles((theme: Theme) => ({
+  tooltip: {
+    backgroundColor: '#f5f5f9',
+    color: 'rgba(0, 0, 0, 0.87)',
+    maxWidth: 220,
+    fontSize: theme.typography.pxToRem(12),
+    border: '1px solid #dadde9',
+  },
+}))(Tooltip)
+
+export default HtmlTooltip

--- a/src/components/TrackSelector/LiveTalkModalButton.tsx
+++ b/src/components/TrackSelector/LiveTalkModalButton.tsx
@@ -1,6 +1,7 @@
 import React, { ReactElement, useState } from 'react'
 import * as Styled from './styled'
 import { FormatListBulleted } from '@material-ui/icons'
+import HtmlTooltip from './HtmlTooltip'
 
 type Props = {
   content: (closeModal: () => void) => ReactElement
@@ -11,13 +12,15 @@ export const LiveTalkModalButton: React.FC<Props> = ({ content }) => {
 
   return (
     <>
-      <Styled.LiveTalkModalButton
-        data-testid="btn"
-        color="primary"
-        onClick={() => setModalOpen(true)}
-      >
-        <FormatListBulleted />
-      </Styled.LiveTalkModalButton>
+      <HtmlTooltip title="ライブセッション">
+        <Styled.LiveTalkModalButton
+          data-testid="btn"
+          color="primary"
+          onClick={() => setModalOpen(true)}
+        >
+          <FormatListBulleted />
+        </Styled.LiveTalkModalButton>
+      </HtmlTooltip>
       <Styled.LiveTalkModal
         open={isModalOpen}
         onClose={() => setModalOpen(false)}

--- a/src/components/TrackSelector/PTrackSelectorButtonGroup.tsx
+++ b/src/components/TrackSelector/PTrackSelectorButtonGroup.tsx
@@ -1,10 +1,9 @@
 import React from 'react'
 import * as Styled from './styled'
 import { Talk, Track } from '../../generated/dreamkast-api.generated'
-import { Theme, Tooltip } from '@material-ui/core'
 import dayjs from 'dayjs'
-import { withStyles } from '@material-ui/styles'
 import { setupDayjs } from '../../util/setupDayjs'
+import HtmlTooltip from './HtmlTooltip'
 
 setupDayjs()
 
@@ -61,13 +60,3 @@ export const PTrackSelectorButtonGroup: React.FC<Props> = ({
     </Styled.TrackSelectorButtonGroup>
   )
 }
-
-const HtmlTooltip = withStyles((theme: Theme) => ({
-  tooltip: {
-    backgroundColor: '#f5f5f9',
-    color: 'rgba(0, 0, 0, 0.87)',
-    maxWidth: 220,
-    fontSize: theme.typography.pxToRem(12),
-    border: '1px solid #dadde9',
-  },
-}))(Tooltip)

--- a/src/components/TrackSelector/ShowLTButton.tsx
+++ b/src/components/TrackSelector/ShowLTButton.tsx
@@ -1,24 +1,20 @@
 import React from 'react'
 import * as Styled from './styled'
-import { PeopleAlt } from '@material-ui/icons'
 import { showLT } from '../../store/settings'
 import { useDispatch } from 'react-redux'
-import HtmlTooltip from './HtmlTooltip'
 
 export const ShowLTButton: React.FC = () => {
   const dispatch = useDispatch()
 
   return (
-    <HtmlTooltip title="コミュニティLT">
-      <Styled.ShowLTButton
-        data-testid="btn"
-        color="primary"
-        onClick={() => {
-          dispatch(showLT())
-        }}
-      >
-        <PeopleAlt />
-      </Styled.ShowLTButton>
-    </HtmlTooltip>
+    <Styled.ShowLTButton
+      data-testid="btn"
+      color="primary"
+      onClick={() => {
+        dispatch(showLT())
+      }}
+    >
+      Community LT
+    </Styled.ShowLTButton>
   )
 }

--- a/src/components/TrackSelector/ShowLTButton.tsx
+++ b/src/components/TrackSelector/ShowLTButton.tsx
@@ -1,0 +1,23 @@
+import React from 'react'
+import * as Styled from './styled'
+import { PeopleAlt } from '@material-ui/icons'
+import { showLT } from '../../store/settings'
+import { useDispatch } from 'react-redux'
+
+export const ShowLTButton: React.FC = () => {
+  const dispatch = useDispatch()
+
+  return (
+    <>
+      <Styled.ShowLTButton
+        data-testid="btn"
+        color="primary"
+        onClick={() => {
+          dispatch(showLT())
+        }}
+      >
+        <PeopleAlt />
+      </Styled.ShowLTButton>
+    </>
+  )
+}

--- a/src/components/TrackSelector/ShowLTButton.tsx
+++ b/src/components/TrackSelector/ShowLTButton.tsx
@@ -3,12 +3,13 @@ import * as Styled from './styled'
 import { PeopleAlt } from '@material-ui/icons'
 import { showLT } from '../../store/settings'
 import { useDispatch } from 'react-redux'
+import HtmlTooltip from './HtmlTooltip'
 
 export const ShowLTButton: React.FC = () => {
   const dispatch = useDispatch()
 
   return (
-    <>
+    <HtmlTooltip title="コミュニティLT">
       <Styled.ShowLTButton
         data-testid="btn"
         color="primary"
@@ -18,6 +19,6 @@ export const ShowLTButton: React.FC = () => {
       >
         <PeopleAlt />
       </Styled.ShowLTButton>
-    </>
+    </HtmlTooltip>
   )
 }

--- a/src/components/TrackSelector/TrackSelector.tsx
+++ b/src/components/TrackSelector/TrackSelector.tsx
@@ -5,6 +5,7 @@ import { PLiveTalkList } from './PLiveTalkList'
 import { useDispatch, useSelector } from 'react-redux'
 import {
   setInitialViewTalk,
+  hideLT,
   setViewTrackId,
   useTracks,
   viewTrackIdSelector,
@@ -12,6 +13,7 @@ import {
 import { PTrackSelectorButtonGroup } from './PTrackSelectorButtonGroup'
 import { LiveTalkModalButton } from './LiveTalkModalButton'
 import { ContainerComponent } from '../../util/types'
+import { ShowLTButton } from './ShowLTButton'
 
 export const TrackSelector: React.FC = () => {
   return (
@@ -29,6 +31,7 @@ export const CTrackSelector: ContainerComponent<PProps> = ({ content }) => {
   const handleChange = (selectItem: number | null) => {
     dispatch(setViewTrackId(selectItem))
     dispatch(setInitialViewTalk())
+    dispatch(hideLT())
   }
 
   return content({ viewTrackId, tracksWithLiveTalk, handleChange })
@@ -54,18 +57,21 @@ const PTrackSelector: React.FC<PProps> = ({
           selectedTrack={viewTrackId}
           onChange={handleChange}
         ></PTrackSelectorButtonGroup>
-        <LiveTalkModalButton
-          content={(closeModal) => (
-            <PLiveTalkList
-              data={tracksWithLiveTalk}
-              selectedTrack={viewTrackId}
-              onChange={(i) => {
-                closeModal()
-                handleChange(i)
-              }}
-            />
-          )}
-        ></LiveTalkModalButton>
+        <Styled.OptionButtonGroup>
+          <LiveTalkModalButton
+            content={(closeModal) => (
+              <PLiveTalkList
+                data={tracksWithLiveTalk}
+                selectedTrack={viewTrackId}
+                onChange={(i) => {
+                  closeModal()
+                  handleChange(i)
+                }}
+              />
+            )}
+          ></LiveTalkModalButton>
+          <ShowLTButton />
+        </Styled.OptionButtonGroup>
       </Styled.TrackMenuContainer>
     </>
   )

--- a/src/components/TrackSelector/__tests__/LiveTalkModalButton.spec.tsx
+++ b/src/components/TrackSelector/__tests__/LiveTalkModalButton.spec.tsx
@@ -1,26 +1,32 @@
 import React from 'react'
 import { fireEvent, render } from '@testing-library/react'
 import { LiveTalkModalButton } from '../LiveTalkModalButton'
+import theme from '../../../styles/theme'
+import { ThemeProvider as MUIThemeProvider } from '@material-ui/styles'
 
 describe('LiveTalkModalButton', () => {
   it('should not render modal by default', () => {
     const screen = render(
-      <LiveTalkModalButton
-        content={(closeModal) => (
-          <div data-testid={'tgt'} onClick={() => closeModal()} />
-        )}
-      ></LiveTalkModalButton>,
+      <MUIThemeProvider theme={theme}>
+        <LiveTalkModalButton
+          content={(closeModal) => (
+            <div data-testid={'tgt'} onClick={() => closeModal()} />
+          )}
+        ></LiveTalkModalButton>
+      </MUIThemeProvider>,
     )
     expect(screen.queryByTestId('tgt')).toBeNull()
   })
 
   it('should render modal when button clicked', () => {
     const screen = render(
-      <LiveTalkModalButton
-        content={(closeModal) => (
-          <div data-testid={'tgt'} onClick={() => closeModal()} />
-        )}
-      ></LiveTalkModalButton>,
+      <MUIThemeProvider theme={theme}>
+        <LiveTalkModalButton
+          content={(closeModal) => (
+            <div data-testid={'tgt'} onClick={() => closeModal()} />
+          )}
+        ></LiveTalkModalButton>
+      </MUIThemeProvider>,
     )
     fireEvent.click(screen.getByTestId('btn'))
     expect(screen.queryByTestId('tgt')).toBeTruthy()
@@ -28,11 +34,13 @@ describe('LiveTalkModalButton', () => {
 
   it('should hide modal when closeModal called', () => {
     const screen = render(
-      <LiveTalkModalButton
-        content={(closeModal) => (
-          <div data-testid={'tgt'} onClick={() => closeModal()} />
-        )}
-      ></LiveTalkModalButton>,
+      <MUIThemeProvider theme={theme}>
+        <LiveTalkModalButton
+          content={(closeModal) => (
+            <div data-testid={'tgt'} onClick={() => closeModal()} />
+          )}
+        ></LiveTalkModalButton>
+      </MUIThemeProvider>,
     )
     fireEvent.click(screen.getByTestId('btn'))
     expect(screen.queryByTestId('tgt')).toBeTruthy()

--- a/src/components/TrackSelector/__tests__/__snapshots__/PLiveTrackList.spec.tsx.snap
+++ b/src/components/TrackSelector/__tests__/__snapshots__/PLiveTrackList.spec.tsx.snap
@@ -3,18 +3,18 @@
 exports[`PLiveTrackList should render when data empty 1`] = `
 <DocumentFragment>
   <div
-    class="styled__Container-sc-hs19f1-5 eqHUdD"
+    class="styled__Container-sc-hs19f1-7 idycAZ"
   >
     <div
-      class="styled__InnerContainer-sc-hs19f1-6 gvdjxY"
+      class="styled__InnerContainer-sc-hs19f1-8 ckLkIy"
     >
       <div
-        class="styled__Title-sc-hs19f1-7 fJkCvo"
+        class="styled__Title-sc-hs19f1-9 coGCFq"
       >
         ライブセッション
       </div>
       <div
-        class="styled__List-sc-hs19f1-8 cXvUFU"
+        class="styled__List-sc-hs19f1-10 gueQKZ"
       >
         <div
           class="MuiTableContainer-root"
@@ -37,18 +37,18 @@ exports[`PLiveTrackList should render when data empty 1`] = `
 exports[`PLiveTrackList should render without crash 1`] = `
 <DocumentFragment>
   <div
-    class="styled__Container-sc-hs19f1-5 eqHUdD"
+    class="styled__Container-sc-hs19f1-7 idycAZ"
   >
     <div
-      class="styled__InnerContainer-sc-hs19f1-6 gvdjxY"
+      class="styled__InnerContainer-sc-hs19f1-8 ckLkIy"
     >
       <div
-        class="styled__Title-sc-hs19f1-7 fJkCvo"
+        class="styled__Title-sc-hs19f1-9 coGCFq"
       >
         ライブセッション
       </div>
       <div
-        class="styled__List-sc-hs19f1-8 cXvUFU"
+        class="styled__List-sc-hs19f1-10 gueQKZ"
       >
         <div
           class="MuiTableContainer-root"
@@ -68,7 +68,7 @@ exports[`PLiveTrackList should render without crash 1`] = `
                   style="width: 150px;"
                 >
                   <button
-                    class="MuiButtonBase-root MuiButton-root MuiButton-text styled__TrackSelectorButton-sc-hs19f1-9 dwBMoN"
+                    class="MuiButtonBase-root MuiButton-root MuiButton-text styled__TrackSelectorButton-sc-hs19f1-11 htnZVk"
                     tabindex="0"
                     type="button"
                   >
@@ -86,7 +86,7 @@ exports[`PLiveTrackList should render without crash 1`] = `
                   class="MuiTableCell-root MuiTableCell-body MuiTableCell-alignLeft"
                 >
                   <span
-                    class="styled__Live-sc-hs19f1-10 dHiCAc"
+                    class="styled__Live-sc-hs19f1-12 jNCZBC"
                   >
                     LIVE
                   </span>
@@ -105,7 +105,7 @@ exports[`PLiveTrackList should render without crash 1`] = `
                   style="width: 150px;"
                 >
                   <button
-                    class="MuiButtonBase-root MuiButton-root MuiButton-text styled__TrackSelectorButton-sc-hs19f1-9 dwBMoN"
+                    class="MuiButtonBase-root MuiButton-root MuiButton-text styled__TrackSelectorButton-sc-hs19f1-11 htnZVk"
                     tabindex="0"
                     type="button"
                   >
@@ -137,7 +137,7 @@ exports[`PLiveTrackList should render without crash 1`] = `
                   style="width: 150px;"
                 >
                   <button
-                    class="MuiButtonBase-root MuiButton-root MuiButton-text styled__TrackSelectorButton-sc-hs19f1-9 dwBMoN"
+                    class="MuiButtonBase-root MuiButton-root MuiButton-text styled__TrackSelectorButton-sc-hs19f1-11 htnZVk"
                     tabindex="0"
                     type="button"
                   >

--- a/src/components/TrackSelector/__tests__/__snapshots__/PTrackSelectorButtonGroup.spec.tsx.snap
+++ b/src/components/TrackSelector/__tests__/__snapshots__/PTrackSelectorButtonGroup.spec.tsx.snap
@@ -3,7 +3,7 @@
 exports[`PTrackSelectorButtonGroup should render when data empty 1`] = `
 <DocumentFragment>
   <div
-    class="MuiToggleButtonGroup-root styled__TrackSelectorButtonGroup-sc-hs19f1-1 bqZiMD"
+    class="MuiToggleButtonGroup-root styled__TrackSelectorButtonGroup-sc-hs19f1-1 gKFsYQ"
     color="primary"
     role="group"
   />
@@ -13,7 +13,7 @@ exports[`PTrackSelectorButtonGroup should render when data empty 1`] = `
 exports[`PTrackSelectorButtonGroup should render without crash 1`] = `
 <DocumentFragment>
   <div
-    class="MuiToggleButtonGroup-root styled__TrackSelectorButtonGroup-sc-hs19f1-1 bqZiMD"
+    class="MuiToggleButtonGroup-root styled__TrackSelectorButtonGroup-sc-hs19f1-1 gKFsYQ"
     color="primary"
     role="group"
   >

--- a/src/components/TrackSelector/__tests__/__snapshots__/PTrackSelectorButtonGroup.spec.tsx.snap
+++ b/src/components/TrackSelector/__tests__/__snapshots__/PTrackSelectorButtonGroup.spec.tsx.snap
@@ -3,7 +3,7 @@
 exports[`PTrackSelectorButtonGroup should render when data empty 1`] = `
 <DocumentFragment>
   <div
-    class="MuiToggleButtonGroup-root styled__TrackSelectorButtonGroup-sc-hs19f1-1 dNfNcj"
+    class="MuiToggleButtonGroup-root styled__TrackSelectorButtonGroup-sc-hs19f1-1 bqZiMD"
     color="primary"
     role="group"
   />
@@ -13,7 +13,7 @@ exports[`PTrackSelectorButtonGroup should render when data empty 1`] = `
 exports[`PTrackSelectorButtonGroup should render without crash 1`] = `
 <DocumentFragment>
   <div
-    class="MuiToggleButtonGroup-root styled__TrackSelectorButtonGroup-sc-hs19f1-1 dNfNcj"
+    class="MuiToggleButtonGroup-root styled__TrackSelectorButtonGroup-sc-hs19f1-1 bqZiMD"
     color="primary"
     role="group"
   >

--- a/src/components/TrackSelector/styled.ts
+++ b/src/components/TrackSelector/styled.ts
@@ -10,7 +10,7 @@ export const TrackMenuContainer = styled.div`
 `
 
 export const TrackSelectorButtonGroup = styled(ToggleButtonGroup)`
-  width: calc(100% - 105px);
+  width: calc(100% - 175px);
 `
 
 export const MenuItem = styled(ToggleButton)`
@@ -46,8 +46,8 @@ export const LiveTalkModalButton = styled(IconButton)`
 `
 
 export const ShowLTButton = styled(IconButton)`
-  width: 49.2px;
   height: 49.2px;
+  font-size: 15px;
   border-radius: 5px;
   margin-left: -1px;
   border: 1.5px solid rgba(66, 58, 87, 0.5);

--- a/src/components/TrackSelector/styled.ts
+++ b/src/components/TrackSelector/styled.ts
@@ -10,7 +10,7 @@ export const TrackMenuContainer = styled.div`
 `
 
 export const TrackSelectorButtonGroup = styled(ToggleButtonGroup)`
-  width: calc(100% - 55px);
+  width: calc(100% - 105px);
 `
 
 export const MenuItem = styled(ToggleButton)`
@@ -33,12 +33,23 @@ export const MenuItem = styled(ToggleButton)`
   }
 `
 
-export const LiveTalkModalButton = styled(IconButton)`
+export const OptionButtonGroup = styled.div`
   float: right;
+`
+
+export const LiveTalkModalButton = styled(IconButton)`
   width: 49.2px;
   height: 49.2px;
-  margin-left: 5px;
   border-radius: 5px;
+  border: 1.5px solid rgba(66, 58, 87, 0.5);
+  background-color: #ffffff;
+`
+
+export const ShowLTButton = styled(IconButton)`
+  width: 49.2px;
+  height: 49.2px;
+  border-radius: 5px;
+  margin-left: -1px;
   border: 1.5px solid rgba(66, 58, 87, 0.5);
   background-color: #ffffff;
 `

--- a/src/pages/[eventAbbr]/ui/index.tsx
+++ b/src/pages/[eventAbbr]/ui/index.tsx
@@ -12,6 +12,8 @@ import { ENV } from '../../../config'
 import { useRouter } from 'next/router'
 import { useSelector } from 'react-redux'
 import { authSelector } from '../../../store/auth'
+import { TrackLTView } from '../../../components/TrackLT'
+import { showLTSelector } from '../../../store/settings'
 
 const IndexPage: NextPage = () => {
   return withAuthProvider(<IndexMain />)
@@ -22,6 +24,7 @@ const IndexMain = () => {
   const { event } = useInitSetup(eventAbbr)
   const { refetch } = useGetTalksAndTracks()
   const { roles, dkUrl } = useSelector(authSelector)
+  const showLT = useSelector(showLTSelector)
   const router = useRouter()
 
   // NOTE: TrailMapが必要になったら、以下の3つとpointEventSavingのガードのコメントアウトを解除する
@@ -56,7 +59,16 @@ const IndexMain = () => {
     <NextTalkNotifier>
       <Layout title={event.name} event={event}>
         <TrackSelector />
-        <TrackView event={event} refetch={refetch} />
+        {showLT ? (
+          <TrackLTView
+            event={event}
+            youtubeEmbedLink="https://www.youtube.com/embed/BFRflMJn2lA?si=ArEMJybGrQZ0TG7p"
+            title="コミュニティLT"
+            content="コミュニティLTほげほげ"
+          />
+        ) : (
+          <TrackView event={event} refetch={refetch} />
+        )}
       </Layout>
     </NextTalkNotifier>
   )

--- a/src/pages/[eventAbbr]/ui/index.tsx
+++ b/src/pages/[eventAbbr]/ui/index.tsx
@@ -55,6 +55,22 @@ const IndexMain = () => {
   //   )
   // }
 
+  const content = `各セッションの休憩時間に、技術コミュニティからのLTを行います！
+
+タイムテーブル
+13:00-13:05  一般社団法人LOCAL
+13:05-13:10 PHPカンファレンス北海道
+13:10-13:15 JBUG札幌
+14:05-14:10 学生団体Keisei
+14:10-14:15 TechRAMEN Conference
+15:05-15:10 札幌PHP勉強会
+15:10-15:15 フロントエンドカンファレンス北海道
+16:05-16:10 ゆるWeb勉強会@札幌
+16:10-16:15 SC4Y
+17:05-17:10 Jagu'e'r
+17:10-17:15 JAWS-UG 札幌
+`
+
   return (
     <NextTalkNotifier>
       <Layout title={event.name} event={event}>
@@ -64,7 +80,7 @@ const IndexMain = () => {
             event={event}
             youtubeEmbedLink="https://www.youtube.com/embed/BFRflMJn2lA?si=ArEMJybGrQZ0TG7p"
             title="コミュニティLT"
-            content="コミュニティLTほげほげ"
+            content={content}
           />
         ) : (
           <TrackView event={event} refetch={refetch} />

--- a/src/store/settings.ts
+++ b/src/store/settings.ts
@@ -60,6 +60,9 @@ type SettingsState = {
   // 事前登録セッションが開始したら通知するモード
   notifyRegisteredTalkStarted: boolean
   nextRegisteredTalk: { talk: Talk | null; track: Track | null }
+
+  // LT画面表示
+  showLT: boolean
 }
 
 const initialState: SettingsState = {
@@ -80,6 +83,7 @@ const initialState: SettingsState = {
   isLiveMode: true,
   notifyRegisteredTalkStarted: true,
   nextRegisteredTalk: { talk: null, track: null },
+  showLT: false,
 }
 
 const settingsSlice = createSlice({
@@ -315,6 +319,15 @@ const settingsSlice = createSlice({
         s.isLiveMode = false
       }
     },
+    showLT: (s) => {
+      s.viewTrackId = 0
+      s.viewTalkId = 0
+      s.isLiveMode = false
+      s.showLT = true
+    },
+    hideLT: (s) => {
+      s.showLT = false
+    },
   },
 })
 
@@ -332,6 +345,8 @@ export const {
   setInitialViewTalk,
   setIsLiveMode,
   setNotifyRegisteredTalkStarted,
+  showLT,
+  hideLT,
   patchTalksOnAir,
   updateViewTalkWithLiveOne,
   updateNextRegisteredTalk,
@@ -344,6 +359,7 @@ export const profileSelector = createSelector(
 )
 export const tracksSelector = createSelector(settingsSelector, (s) => s.tracks)
 export const talksSelector = createSelector(settingsSelector, (s) => s.talks)
+export const showLTSelector = createSelector(settingsSelector, (s) => s.showLT)
 export const viewTalkIdSelector = createSelector(
   settingsSelector,
   (s) => s.viewTalkId,


### PR DESCRIPTION
https://www.notion.so/pfem/Community-LT-UI-6b863feebe314bf4b9e6d78e11881ba4

で頂いた要件に従い、コミュニティLTを表示する画面を実装しました。

以下のような感じで表示されます。

<img width="1057" alt="image" src="https://github.com/cloudnativedaysjp/dreamkast-ui/assets/19190276/cf40c89d-ccd6-4bdc-bdd7-8a3ea13f8f21">
