### PR TITLE
fix: Add SENTRY_AUTH_TOKEN env var to tag build

### DIFF
--- a/.github/workflows/build-tag.yml
+++ b/.github/workflows/build-tag.yml
@@ -46,3 +46,4 @@ jobs:
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
+          build-args: SENTRY_AUTH_TOKEN=${{ secrets.SENTRY_AUTH_TOKEN }}


### PR DESCRIPTION
tag buildの方にSENTRY_AUTH_TOKENがついていませんでした。