### PR TITLE
callback urlが違う場合上書き可能にする

### DIFF
--- a/src/context/auth.tsx
+++ b/src/context/auth.tsx
@@ -23,27 +23,43 @@ export interface JwtPayload {
   'https://cloudnativedays.jp/roles'?: string[]
 }
 
-export const withAuthProvider = (content: ReactNode) => {
-  return <AuthProvider>{content}</AuthProvider>
+export const withAuthProvider = (content: ReactNode, basePath?: string) => {
+  return <AuthProvider basePath={basePath}>{content}</AuthProvider>
 }
 
-export const AuthProvider = ({ children }: PropsWithChildren) => {
+interface PropsWithChildren {
+  children: React.ReactNode;
+  basePath?: string | null;
+}
+
+export const AuthProvider = ({ children, basePath }: PropsWithChildren) => {
   const { env } = useContext(PrivateCtx)
   const [baseUrl, setBaseUrl] = useState('')
+
 
   useEffect(() => {
     if (!env.NEXT_PUBLIC_BASE_PATH) {
       console.error('Environment variables are not provided as app props.')
       return
     }
-    const url = new URL(env.NEXT_PUBLIC_BASE_PATH, window.location.origin)
-    setBaseUrl(url.href)
-  }, [env])
+    if (basePath) {
+      console.log(`window.location.origin: ${window.location.origin}`)
+      console.log(`basePath: ${basePath}`)
+      const url = new URL(basePath, window.location.origin)
+      console.log(`url: ${url}`)
+      console.log(`url.href: ${url.href}`)
+      setBaseUrl(url.href)
+    } else {
+      const url = new URL(env.NEXT_PUBLIC_BASE_PATH, window.location.origin)
+      setBaseUrl(url.href)
+    }
+  }, [env, basePath])
 
   // Only CSR is supported since dynamic host origin resolution cannot be performed in SSR.
   if (!baseUrl || !env.NEXT_PUBLIC_BASE_PATH) {
     return <></>
   }
+  console.log(`baseUrl: ${baseUrl}`)
   return (
     <>
       <Auth0Provider

--- a/src/context/auth.tsx
+++ b/src/context/auth.tsx
@@ -43,11 +43,7 @@ export const AuthProvider = ({ children, basePath }: PropsWithChildren) => {
       return
     }
     if (basePath) {
-      console.log(`window.location.origin: ${window.location.origin}`)
-      console.log(`basePath: ${basePath}`)
       const url = new URL(basePath, window.location.origin)
-      console.log(`url: ${url}`)
-      console.log(`url.href: ${url.href}`)
       setBaseUrl(url.href)
     } else {
       const url = new URL(env.NEXT_PUBLIC_BASE_PATH, window.location.origin)
@@ -59,7 +55,6 @@ export const AuthProvider = ({ children, basePath }: PropsWithChildren) => {
   if (!baseUrl || !env.NEXT_PUBLIC_BASE_PATH) {
     return <></>
   }
-  console.log(`baseUrl: ${baseUrl}`)
   return (
     <>
       <Auth0Provider

--- a/src/pages/[eventAbbr]/ui/admin/check_in_event/index.tsx
+++ b/src/pages/[eventAbbr]/ui/admin/check_in_event/index.tsx
@@ -1,5 +1,5 @@
 import { NextPage } from 'next'
-import React, { useMemo } from 'react'
+import React, { useContext, useMemo } from 'react'
 import { Layout } from '../../../../../components/Layout'
 import { useGetApiV1EventsByEventAbbrQuery } from '../../../../../generated/dreamkast-api.generated'
 import { useRouter } from 'next/router'
@@ -9,9 +9,14 @@ import { CheckIn } from '../../../../../components/CheckIn/CheckIn'
 import { Typography } from '@material-ui/core'
 import { useSelector } from 'react-redux'
 import { authSelector } from '../../../../../store/auth'
+import { PrivateCtx } from '../../../../../context/private'
 
 const IndexPage: NextPage = () => {
-  return withAuthProvider(<IndexMain />)
+  const { env } = useContext(PrivateCtx)
+  return withAuthProvider(
+    <IndexMain />,
+    `${env.NEXT_PUBLIC_BASE_PATH}/admin/check_in_event`,
+  )
 }
 
 const IndexMain = () => {

--- a/src/pages/[eventAbbr]/ui/admin/check_in_session/index.tsx
+++ b/src/pages/[eventAbbr]/ui/admin/check_in_session/index.tsx
@@ -1,5 +1,5 @@
 import { NextPage } from 'next'
-import React, { useEffect, useMemo, useState } from 'react'
+import React, { useContext, useEffect, useMemo, useState } from 'react'
 import { Layout } from '../../../../../components/Layout'
 import {
   Talk,
@@ -13,9 +13,14 @@ import { CheckIn } from '../../../../../components/CheckIn/CheckIn'
 import { MenuItem, Select, Typography } from '@material-ui/core'
 import { authSelector } from '../../../../../store/auth'
 import { useSelector } from 'react-redux'
+import { PrivateCtx } from '../../../../../context/private'
 
 const IndexPage: NextPage = () => {
-  return withAuthProvider(<IndexMain />)
+  const { env } = useContext(PrivateCtx)
+  return withAuthProvider(
+    <IndexMain />,
+    `/${env.NEXT_PUBLIC_BASE_PATH}/admin/check_in_session`,
+  )
 }
 
 const IndexMain = () => {

--- a/src/pages/[eventAbbr]/ui/info/index.tsx
+++ b/src/pages/[eventAbbr]/ui/info/index.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo } from 'react'
+import React, { useContext, useEffect, useMemo } from 'react'
 import { useRouter } from 'next/router'
 import {
   useGetApiV1EventsByEventAbbrQuery,
@@ -12,9 +12,14 @@ import { RegisteredTalks } from '../../../../components/RegisteredTalks'
 import { Typography } from '@material-ui/core'
 import { ENV } from '../../../../config'
 import { withAuthProvider } from '../../../../context/auth'
+import { PrivateCtx } from '../../../../context/private'
 
 const IndexPage: NextPage = () => {
-  return withAuthProvider(<IndexMain />)
+  const { env } = useContext(PrivateCtx)
+  return withAuthProvider(
+    <IndexMain />,
+    `/${env.NEXT_PUBLIC_BASE_PATH}/info`,
+  )
 }
 
 const IndexMain: NextPage = () => {


### PR DESCRIPTION
Safariだと `/ui/info` や `/ui/admin/check_in_event` などにアクセスすると `/ui` に遷移してしまう問題がある。これの暫定対処？として、各ページのwithAuthProviderでcallback urlを上書きできるようにする。Auth0側のAllows Callback Urlsの更新も必要。

なお、chromeだと修正前のコードでも問題なく各ページにアクセスできるので、根本的に修正方針が間違っている気はする。