### PR TITLE
fix: Move AuthProvider to the RootApp to share between all page components

### DIFF
--- a/src/pages/[eventAbbr]/ui/admin/check_in_event/index.tsx
+++ b/src/pages/[eventAbbr]/ui/admin/check_in_event/index.tsx
@@ -3,7 +3,6 @@ import React, { useMemo } from 'react'
 import { Layout } from '../../../../../components/Layout'
 import { useGetApiV1EventsByEventAbbrQuery } from '../../../../../generated/dreamkast-api.generated'
 import { useRouter } from 'next/router'
-import { withAuthProvider } from '../../../../../context/auth'
 import Error404 from '../../../../404'
 import { CheckIn } from '../../../../../components/CheckIn/CheckIn'
 import { Typography } from '@material-ui/core'
@@ -11,7 +10,7 @@ import { useSelector } from 'react-redux'
 import { authSelector } from '../../../../../store/auth'
 
 const IndexPage: NextPage = () => {
-  return withAuthProvider(<IndexMain />)
+  return <IndexMain />
 }
 
 const IndexMain = () => {

--- a/src/pages/[eventAbbr]/ui/admin/check_in_session/index.tsx
+++ b/src/pages/[eventAbbr]/ui/admin/check_in_session/index.tsx
@@ -7,7 +7,6 @@ import {
   useGetApiV1TalksQuery,
 } from '../../../../../generated/dreamkast-api.generated'
 import { useRouter } from 'next/router'
-import { withAuthProvider } from '../../../../../context/auth'
 import Error404 from '../../../../404'
 import { CheckIn } from '../../../../../components/CheckIn/CheckIn'
 import { MenuItem, Select, Typography } from '@material-ui/core'
@@ -15,7 +14,7 @@ import { authSelector } from '../../../../../store/auth'
 import { useSelector } from 'react-redux'
 
 const IndexPage: NextPage = () => {
-  return withAuthProvider(<IndexMain />)
+  return <IndexMain />
 }
 
 const IndexMain = () => {

--- a/src/pages/[eventAbbr]/ui/index.tsx
+++ b/src/pages/[eventAbbr]/ui/index.tsx
@@ -6,7 +6,6 @@ import { NextPage } from 'next'
 import { useInitSetup } from '../../../components/hooks/useInitSetup'
 import { useGetTalksAndTracks } from '../../../components/hooks/useGetTalksAndTracks'
 import { useRouterQuery } from '../../../components/hooks/useRouterQuery'
-import { withAuthProvider } from '../../../context/auth'
 import { NextTalkNotifier } from '../../../components/Layout/NextTalkNotifier'
 import { ENV } from '../../../config'
 import { useRouter } from 'next/router'
@@ -16,7 +15,7 @@ import { TrackLTView } from '../../../components/TrackLT'
 import { showLTSelector } from '../../../store/settings'
 
 const IndexPage: NextPage = () => {
-  return withAuthProvider(<IndexMain />)
+  return <IndexMain />
 }
 
 const IndexMain = () => {
@@ -90,7 +89,7 @@ const IndexMain = () => {
   )
 }
 
-// TODO move to RootApp component
+// TODO remove this ( seems not needed )
 export const getServerSideProps = async () => {
   return {
     props: {

--- a/src/pages/[eventAbbr]/ui/info/index.tsx
+++ b/src/pages/[eventAbbr]/ui/info/index.tsx
@@ -11,10 +11,9 @@ import { Layout } from '../../../../components/Layout'
 import { RegisteredTalks } from '../../../../components/RegisteredTalks'
 import { Typography } from '@material-ui/core'
 import { ENV } from '../../../../config'
-import { withAuthProvider } from '../../../../context/auth'
 
 const IndexPage: NextPage = () => {
-  return withAuthProvider(<IndexMain />)
+  return <IndexMain />
 }
 
 const IndexMain: NextPage = () => {

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -19,6 +19,7 @@ import { setApiBaseUrl, setDkUrl, setWsBaseUrl } from '../store/auth'
 import { ENV, validateEnv } from '../config'
 import { PrivateCtxProvider } from '../context/private'
 import { ApolloClient, InMemoryCache, ApolloProvider } from '@apollo/client'
+import { AuthProvider } from 'src/context/auth'
 
 const GlobalStyle = createGlobalStyle`
   html, body {
@@ -84,7 +85,9 @@ const RootApp = ({ Component, pageProps, env }: RootAppProps) => {
       <PrivateCtxProvider env={env}>
         <AppComponent>
           <ApolloProvider client={client}>
-            <Component {...pageProps} />
+            <AuthProvider>
+              <Component {...pageProps} />
+            </AuthProvider>
           </ApolloProvider>
         </AppComponent>
       </PrivateCtxProvider>


### PR DESCRIPTION
safariで3rd party tracking cookie blockingが有効なブラウザで、infoやcheck_in_event にアクセスすると /authroizeが都度走ってしまい /ui にredirectされる件の対処です。

そもそも、上記の事象は、
1. 各pageにアクセスしたときに、access_tokenの取得処理（/authorizeのcall）が走ってしまう
2. 3rd party cookieがblockされると、auth0 libraryのgetTokenSilentlyが通らない
3. redirectを伴う再認証処理が走ってしまう

が原因です。
一方で、初回アクセス時に認証してaccess_tokenは取得済であり、そもそも1で /authorize のcallが走ることがよくないです。
これは、各pageごとにwithAuthProviderを実行しており、pageの切替時にAuthProviderがdestroy-and-recreateされてしまっているからです。

NextjsのPageRouterを使っている場合、_app.tsxで定義されているtop levelのRootAppであれば、pageを切り替えても引き継がれます。AuthProviderの実行をここに移すことで、pageを切り替えてもstateが維持され、/authorizeのcallが実行されないようにしました。

この対応により、safariでも/info が表示できることを確認しました。

1点、今回の対応により無認証のページが表示できなくなっています。
ただ、これに関しては別の方式で対応すべきであり、pageを切り替えても認証状態は維持される方が望ましいので、今回の対応は無認証ページが混在する場合でも導入するべきと考えます。
