### PR TITLE
fix: Use nextlink for check_in_operation pages

### DIFF
--- a/src/components/Menu/internal/AdminMobileMenu/AdminMobileMenu.tsx
+++ b/src/components/Menu/internal/AdminMobileMenu/AdminMobileMenu.tsx
@@ -4,6 +4,7 @@ import CheckIcon from '@material-ui/icons/Check'
 import KeyboardArrowRightIcon from '@material-ui/icons/KeyboardArrowRight'
 import * as Styled from './styled'
 import * as CommonStyled from '../../../../styles/styled'
+import Link from 'next/link'
 import { Event } from '../../../../generated/dreamkast-api.generated'
 
 type Props = {
@@ -24,24 +25,21 @@ export const AdminMobileMenu: React.FC<Props> = ({ event }) => {
         <ListItemIcon>
           <CheckIcon />
         </ListItemIcon>
-        <CommonStyled.MenuLink
-          href={`/${event?.abbr}/ui/admin/check_in_event`}
-          rel="noreferrer noopener"
-        >
+        <Link href={`/${event?.abbr}/ui/admin/check_in_event`} rel="noreferrer">
           <Button style={{ color: '#423A57' }}>Check-In (Event)</Button>
-        </CommonStyled.MenuLink>
+        </Link>
       </Styled.NestedListItem>
 
       <Styled.NestedListItem button key="check_in_session">
         <ListItemIcon>
           <CheckIcon />
         </ListItemIcon>
-        <CommonStyled.MenuLink
+        <Link
           href={`/${event?.abbr}/ui/admin/check_in_session`}
-          rel="noreferrer noopener"
+          rel="noreferrer"
         >
           <Button style={{ color: '#423A57' }}>Check-In (Session)</Button>
-        </CommonStyled.MenuLink>
+        </Link>
       </Styled.NestedListItem>
     </div>
   )

--- a/src/components/Menu/internal/AdminMobileMenu/AdminMobileMenu.tsx
+++ b/src/components/Menu/internal/AdminMobileMenu/AdminMobileMenu.tsx
@@ -3,7 +3,6 @@ import { Button, ListItem, ListItemIcon, ListItemText } from '@material-ui/core'
 import CheckIcon from '@material-ui/icons/Check'
 import KeyboardArrowRightIcon from '@material-ui/icons/KeyboardArrowRight'
 import * as Styled from './styled'
-import * as CommonStyled from '../../../../styles/styled'
 import Link from 'next/link'
 import { Event } from '../../../../generated/dreamkast-api.generated'
 


### PR DESCRIPTION
NextLinkにして、page全体のre-renderingが発生しないようにしました。