### PR TITLE
fix: Force rehearsal mode even when the pre-conference or conference day

### DIFF
--- a/src/store/settings.ts
+++ b/src/store/settings.ts
@@ -102,9 +102,9 @@ const settingsSlice = createSlice({
       let confDay = action.payload?.conferenceDays?.find(
         (day) => day.date === today,
       )
-      if (!confDay && state.event.rehearsalMode) {
+      if (state.event.rehearsalMode) {
         console.warn(
-          '### rehearsal mode: fallback to the non-internal confence day',
+          '### rehearsal mode: fallback to the non-internal conference day',
         )
         confDay = (action.payload?.conferenceDays || [])?.find(
           (conf) => !conf.internal,


### PR DESCRIPTION
プレイベをdkでやらなかった場合に、カンファレンス前日にプレイベの予定が入っていることが多いですが、このケースにおいてdkから取得できた日付を優先すると、前日リハでプレイベ側のデータを取りに行ってしまい困ります。

リハーサルモードの場合は、プレイベの日だろうがカンファレンス当日のデータを取りに行くようにしました。