### PR TITLE
Update Sentry DSN

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -34,7 +34,7 @@ const sentryWebpackPluginOptions = {
   //   release, url, authToken, configFile, stripPrefix,
   //   urlPrefix, include, ignore
 
-  org: 'cloudnativedays',
+  org: 'cloudnative-days',
   project: 'dreamkast-ui',
 
   silent: true, // Suppresses all logs

--- a/sentry.client.config.js
+++ b/sentry.client.config.js
@@ -9,7 +9,7 @@ const SENTRY_DSN = process.env.SENTRY_DSN || process.env.NEXT_PUBLIC_SENTRY_DSN
 Sentry.init({
   dsn:
     SENTRY_DSN ||
-    'https://dbf0f30514094bed721121dc94ee19b2@sentry.cloudnativedays.jp/4',
+    'https://144c5d72cbf1da0931ff09532d25b11d@o414348.ingest.us.sentry.io/4509089547747328',
   // Adjust this value in production, or use tracesSampler for greater control
   tracesSampleRate: 0.5,
   sampleRate: 0.5,

--- a/sentry.edge.config.js
+++ b/sentry.edge.config.js
@@ -9,7 +9,7 @@ const SENTRY_DSN = process.env.SENTRY_DSN || process.env.NEXT_PUBLIC_SENTRY_DSN
 Sentry.init({
   dsn:
     SENTRY_DSN ||
-    'https://dbf0f30514094bed721121dc94ee19b2@sentry.cloudnativedays.jp/4',
+    'https://144c5d72cbf1da0931ff09532d25b11d@o414348.ingest.us.sentry.io/4509089547747328',
   // Adjust this value in production, or use tracesSampler for greater control
   tracesSampleRate: 0.5,
   sampleRate: 0.5,

--- a/sentry.properties
+++ b/sentry.properties
@@ -1,4 +1,4 @@
-defaults.url=https://sentry.cloudnativedays.jp/
-defaults.org=cloudnativedays
+defaults.url=https://cloudnative-days.sentry.io/
+defaults.org=cloudnative-days
 defaults.project=dreamkast-ui
 cli.executable=node_modules/@sentry/cli/bin/sentry-cli

--- a/sentry.server.config.js
+++ b/sentry.server.config.js
@@ -9,7 +9,7 @@ const SENTRY_DSN = process.env.SENTRY_DSN || process.env.NEXT_PUBLIC_SENTRY_DSN
 Sentry.init({
   dsn:
     SENTRY_DSN ||
-    'https://dbf0f30514094bed721121dc94ee19b2@sentry.cloudnativedays.jp/4',
+    'https://144c5d72cbf1da0931ff09532d25b11d@o414348.ingest.us.sentry.io/4509089547747328',
   // Adjust this value in production, or use tracesSampler for greater control
   tracesSampleRate: 0.5,
   sampleRate: 0.5,


### PR DESCRIPTION
- Sentryをクラウド版に移行するため、DSNをクラウド版のSentryのものに修正しました