### PR TITLE
Remove printer selection requirement from event check-in

### DIFF
--- a/src/pages/[eventAbbr]/ui/admin/check_in_event/index.tsx
+++ b/src/pages/[eventAbbr]/ui/admin/check_in_event/index.tsx
@@ -1,15 +1,13 @@
 import { NextPage } from 'next'
-import React, { useEffect, useMemo, useState } from 'react'
+import React, { useMemo } from 'react'
 import { Layout } from '../../../../../components/Layout'
 import {
-  PrintNodePrinter,
   useGetApiV1EventsByEventAbbrQuery,
-  useGetApiV1PrintNodePrintersQuery,
 } from '../../../../../generated/dreamkast-api.generated'
 import { useRouter } from 'next/router'
 import Error404 from '../../../../404'
 import { CheckIn } from '../../../../../components/CheckIn/CheckIn'
-import { MenuItem, Select, Typography } from '@material-ui/core'
+import { Typography } from '@material-ui/core'
 import { useSelector } from 'react-redux'
 import { authSelector } from '../../../../../store/auth'
 import { ENV } from '../../../../../config'
@@ -34,30 +32,6 @@ const IndexMain = () => {
     { eventAbbr },
     { skip },
   )
-  const [printers, setPrinters] = useState<PrintNodePrinter[]>([])
-  const { data, isLoading, isError, error } = useGetApiV1PrintNodePrintersQuery(
-    { eventAbbr },
-  )
-  useEffect(() => {
-    if (isLoading) {
-      return
-    }
-    if (isError) {
-      throw error
-    }
-    if (data) {
-      console.log(data)
-      setPrinters(data)
-    }
-  }, [data, isLoading, isError])
-
-  const [selectedPrinter, setSelectedPrinter] =
-    useState<PrintNodePrinter | null>(null)
-  const handleSelectChange = (event: React.ChangeEvent<{ value: unknown }>) => {
-    setSelectedPrinter(
-      printers.find((printer) => printer.id === event.target.value) || null,
-    )
-  }
   if (event) {
     if (isAdminRole) {
       return (
@@ -65,25 +39,10 @@ const IndexMain = () => {
           <Typography variant="h5">
             イベント受付 ({event.abbr.toUpperCase()})
           </Typography>
-          (
-          <Select
-            value={selectedPrinter ? selectedPrinter.id : 'default'}
-            onChange={handleSelectChange}
-          >
-            <MenuItem value="default">プリンターを選択</MenuItem>
-            {printers.map((printer) => {
-              return <MenuItem value={printer.id}>{printer.name}</MenuItem>
-            })}
-          </Select>
-          )
-          {selectedPrinter != null && (
-            <CheckIn
-              key={selectedPrinter.id}
-              checkInType={'event'}
-              eventAbbr={event.abbr}
-              printerId={selectedPrinter.id}
-            />
-          )}
+          <CheckIn
+            checkInType={'event'}
+            eventAbbr={event.abbr}
+          />
         </Layout>
       )
     } else {


### PR DESCRIPTION
Allow QR code scanning without printer selection to improve usability when printer is not available or needed.

🤖 Generated with [Claude Code](https://claude.ai/code)