### PR TITLE
fix: リハーサルモード切替時にトラック内セッションを切り替えられない問題を修正

### DIFF
--- a/src/components/TalkSelector/TalkSelector.tsx
+++ b/src/components/TalkSelector/TalkSelector.tsx
@@ -57,7 +57,7 @@ export const PTalkSelector: React.FC<PProps> = ({
 }) => {
   const availableTalks = useMemo(
     () => extractAvailableTalks(talks, now, isRehearsal),
-    [talks, now],
+    [talks, now, isRehearsal],
   )
 
   return (


### PR DESCRIPTION
## Summary
- `TalkSelector` の `useMemo` 依存配列に `isRehearsal` が含まれておらず、リハーサルモードに切り替えても `availableTalks` が再計算されないバグを修正
- 結果としてトラック内セッションの切替ボタンが `disabled` のままになり、リハーサル本来の「即時に全セッションへ切替可」が機能していなかった

## Test plan
- [ ] リハーサルモードを有効にした状態でトラックページを開き、現在時刻外のセッションも切替可能になることを確認
- [ ] 通常モードでは従来どおり、開始時刻に達したセッションのみ切替可能であることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)