### PR TITLE
fix: reset SessionQA state when talk changes

### DIFF
--- a/src/components/SessionQA/SessionQA.tsx
+++ b/src/components/SessionQA/SessionQA.tsx
@@ -131,14 +131,9 @@ export const SessionQA: React.FC<Props> = ({ talk }) => {
 
   // 質問データを状態に反映（初回ロード時のみ）
   // WebSocket更新を優先するため、questionsDataの更新は初回ロード時のみ
+  // talk切り替え時はTrack.tsxで`key={selectedTalk?.id}`によりリマウントされるため、
+  // ここでフラグをリセットする必要はない
   const isInitializedRef = React.useRef(false)
-
-  // talk切り替え時に初期化フラグと質問リストをリセット
-  useEffect(() => {
-    isInitializedRef.current = false
-    setQuestions([])
-  }, [talk?.id])
-
   useEffect(() => {
     if (questionsData?.questions && !isInitializedRef.current) {
       // 初回ロード時のみAPIデータを使用

--- a/src/components/SessionQA/SessionQA.tsx
+++ b/src/components/SessionQA/SessionQA.tsx
@@ -132,6 +132,13 @@ export const SessionQA: React.FC<Props> = ({ talk }) => {
   // 質問データを状態に反映（初回ロード時のみ）
   // WebSocket更新を優先するため、questionsDataの更新は初回ロード時のみ
   const isInitializedRef = React.useRef(false)
+
+  // talk切り替え時に初期化フラグと質問リストをリセット
+  useEffect(() => {
+    isInitializedRef.current = false
+    setQuestions([])
+  }, [talk?.id])
+
   useEffect(() => {
     if (questionsData?.questions && !isInitializedRef.current) {
       // 初回ロード時のみAPIデータを使用

--- a/src/components/Track/Track.tsx
+++ b/src/components/Track/Track.tsx
@@ -90,7 +90,7 @@ export const TrackView: React.FC<Props> = ({ event, refetch }) => {
           <Sponsors event={event} />
         </Grid>
         <Grid item xs={12} md={4}>
-          <SessionQA event={event} talk={selectedTalk} />
+          <SessionQA key={selectedTalk?.id} event={event} talk={selectedTalk} />
         </Grid>
         <Grid item xs={12} md={8} style={{ height: '100%' }}>
           <TalkInfo
@@ -126,7 +126,7 @@ export const TrackView: React.FC<Props> = ({ event, refetch }) => {
           />
         </Grid>
         <Grid item xs={12} md={4}>
-          <SessionQA event={event} talk={selectedTalk} />
+          <SessionQA key={selectedTalk?.id} event={event} talk={selectedTalk} />
         </Grid>
         <Grid item xs={12} md={4}>
           <TalkSelector


### PR DESCRIPTION
## Summary
- オンエアのセッションが切り替わったときに、SessionQA が前のセッションの質問を表示し続ける問題を修正
- `isInitializedRef` が talk 切り替え時にリセットされず、新しい talk のクエリ結果がステートに反映されていなかった

## 原因
`SessionQA.tsx` の `isInitializedRef` は「WebSocket 更新を優先するため、API レスポンスでステートを上書きしない」という意図で導入されていたが、`talk?.id` が変わってもリセットされないため:

1. talk A で `isInitializedRef.current = true`
2. オンエアが talk B に切り替わる
3. クエリは新しい `talk.id` で再フェッチされ `questionsData` は更新される
4. しかし `isInitializedRef.current` が true のままなので初期化 useEffect が `setQuestions` を呼ばない
5. 古い talk A の質問が表示され続ける

(commit 2102c94 で生成APIフックに移行した際の regression)

## Fix
`talk?.id` 変更時にフラグと質問リストをリセットする useEffect を追加。これを既存の初期化 useEffect の前に置くことで、talk 切り替え → リセット → 新しい `questionsData` による再初期化 という流れになる。

```tsx
useEffect(() => {
  isInitializedRef.current = false
  setQuestions([])
}, [talk?.id])
```

WebSocket 購読側は既に `talk?.id` 依存で再接続するようになっているので追加対応は不要。

## Test plan
- [x] `yarn type-check` 通過
- [x] `yarn jest src/components/SessionQA` 通過 (16 tests)
- [ ] ブラウザでオンエアセッションを切り替えたとき、QA パネルが新しいセッションの質問に切り替わることを確認
- [ ] 切り替え後の WebSocket 経由での質問追加・投票・回答が新セッションで動くことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)