### PR TITLE
fix(SessionQA): speaker reply, vote color, post flicker

### DIFF
--- a/schemas/swagger.yml
+++ b/schemas/swagger.yml
@@ -1194,6 +1194,9 @@ components:
       properties:
         id:
           type: number
+        userId:
+          type: number
+          nullable: true
         name:
           type: string
         email:
@@ -1417,6 +1420,9 @@ components:
                 type: number
               name:
                 type: string
+              userId:
+                type: number
+                nullable: true
         dayId:
           type: number
           nullable: true

--- a/src/components/SessionQA/SessionQA.tsx
+++ b/src/components/SessionQA/SessionQA.tsx
@@ -222,8 +222,10 @@ export const SessionQA: React.FC<Props> = ({ talk }) => {
           talkId: talk.id,
           id: questionId,
         }).unwrap()
-        setQuestions((prev) =>
-          prev.map((q) =>
+        // 投票数が変わるため、現在のソートを再適用しないと
+        // 投票数順表示時に並びが古いままになる（WebSocket に依存しない）
+        setQuestions((prev) => {
+          const updated = prev.map((q) =>
             q.id === questionId
               ? {
                   ...q,
@@ -231,13 +233,14 @@ export const SessionQA: React.FC<Props> = ({ talk }) => {
                   votes_count: response.votes_count,
                 }
               : q,
-          ),
-        )
+          )
+          return sortQuestions(updated, sortByRef.current)
+        })
       } catch (error) {
         console.error('Failed to vote:', error)
       }
     },
-    [talk?.id, voteQuestion],
+    [talk?.id, voteQuestion, sortQuestions],
   )
 
   const handleAnswerSubmit = useCallback(

--- a/src/components/SessionQA/SessionQA.tsx
+++ b/src/components/SessionQA/SessionQA.tsx
@@ -46,9 +46,12 @@ export const SessionQA: React.FC<Props> = ({ talk }) => {
   }, [sortBy])
 
   // RTK Query hooks (生成されたAPIフックを使用)
+  // ソートはクライアント側で行うため API クエリには sort を渡さない。
+  // sort をキャッシュキーに含めると、ソート切替時に新規フェッチが走り
+  // isLoading=true で投稿直後の質問が一瞬消える問題が発生する。
   const { data: questionsData, isLoading } =
     useGetApiV1TalksByTalkIdSessionQuestionsQuery(
-      { talkId: talk?.id || 0, sort: sortBy },
+      { talkId: talk?.id || 0 },
       { skip: !talk?.id },
     )
 
@@ -98,17 +101,18 @@ export const SessionQA: React.FC<Props> = ({ talk }) => {
           return sortQuestions(updated, sortByRef.current)
         })
       } else if (message.type === 'question_voted') {
+        // has_voted は投票したユーザー視点の値で broadcast されるため、
+        // 受信側では votes_count のみ更新する。自分の has_voted は投票 API
+        // のレスポンス（handleVote）でのみ更新される。
         setQuestions((prev) => {
           const updated = prev.map((q) =>
             q.id === message.question_id
               ? {
                   ...q,
                   votes_count: message.votes_count,
-                  has_voted: message.has_voted,
                 }
               : q,
           )
-          // 投票数が変わった場合はソートを再適用（最新のsortByを使用）
           return sortQuestions(updated, sortByRef.current)
         })
       } else if (message.type === 'answer_created') {
@@ -214,10 +218,21 @@ export const SessionQA: React.FC<Props> = ({ talk }) => {
       if (!talk?.id) return
 
       try {
-        await voteQuestion({
+        const response = await voteQuestion({
           talkId: talk.id,
           id: questionId,
         }).unwrap()
+        setQuestions((prev) =>
+          prev.map((q) =>
+            q.id === questionId
+              ? {
+                  ...q,
+                  has_voted: response.has_voted,
+                  votes_count: response.votes_count,
+                }
+              : q,
+          ),
+        )
       } catch (error) {
         console.error('Failed to vote:', error)
       }
@@ -264,13 +279,12 @@ export const SessionQA: React.FC<Props> = ({ talk }) => {
     [talk?.id, deleteQuestion],
   )
 
-  // スピーカー判定
-  // Note: Profile型にspeakerIdが含まれていないため、talk.speakersに含まれるかどうかで判定
-  // 実際の実装では、profile.idとspeakerのuser_idを比較する必要がある可能性がある
+  // スピーカー判定: Profile.userId と Talk.speakers[].userId を比較
+  // どちらも User.id を指すため、一致すれば現在のユーザーがこのトークの
+  // スピーカーであると判定できる。
   const isSpeaker = useMemo(() => {
-    if (!talk || !profile) return false
-    // 暫定的にfalseを返す（実際のスピーカー判定は別途実装が必要）
-    return false
+    if (!talk || !profile?.userId) return false
+    return talk.speakers.some((speaker) => speaker.userId === profile.userId)
   }, [talk, profile])
 
   // 常に質問可能

--- a/src/generated/dreamkast-api.generated.ts
+++ b/src/generated/dreamkast-api.generated.ts
@@ -649,6 +649,7 @@ export type RegisteredTalk = {
 }
 export type Profile = {
   id: number
+  userId?: (number | null) | undefined
   name: string
   email: string
   isAttendOffline: boolean
@@ -740,6 +741,7 @@ export type Talk = {
   speakers: {
     id?: number | undefined
     name?: string | undefined
+    userId?: (number | null) | undefined
   }[]
   dayId: number | null
   showOnTimetable: boolean


### PR DESCRIPTION
## Summary
QA 機能の 3 件の不具合を修正:

- **スピーカーが回答できない** — `isSpeaker` がハードコードで `false` だったため、回答ボタンが表示されない状態だった。`profile.userId === talk.speakers[].userId` で厳密判定するように修正。
- **自分以外が投票しても色が変わる** — WebSocket broadcast の `has_voted` は投票者視点の値なので、受信側で適用すると全クライアントの色が変わってしまう。受信時は `votes_count` のみ更新し、自分の `has_voted` は投票 API レスポンスでのみ更新するよう修正。
- **投稿直後にタブ切替で一瞬投稿が消える** — `sort` を API クエリのキャッシュキーに含めていたため、ソートタブ切替時に再フェッチが走り `isLoading=true` で投稿直後の質問が一瞬消えていた。ソートはローカル (`sortQuestions`) で行うので、API クエリから `sort` を除去。

## Dependencies
- depends on cloudnativedaysjp/dreamkast#2795 (backend で `Profile.userId` と `Talk.speakers[].userId` を公開)
- backend マージ＆デプロイ前に本番反映すると `userId` が `undefined` のままになり `isSpeaker` が常に `false` になります

## Test plan
- [x] TypeScript チェック (関連箇所クリーン)
- [x] `src/components/SessionQA` 配下 Jest 16 件パス
- [ ] 動作確認（backend デプロイ後）
  - [ ] スピーカーアカウントでログインし「回答する」ボタンが表示されることを確認
  - [ ] 別ユーザーが投票しても自分の投票色が変わらないことを確認
  - [ ] 投稿直後にソートタブを切り替えても投稿が消えないことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)