### PR TITLE
feat(AdminMobileMenu): hide Check-In (Event) menu item

### DIFF
--- a/src/components/Menu/internal/AdminMobileMenu/AdminMobileMenu.tsx
+++ b/src/components/Menu/internal/AdminMobileMenu/AdminMobileMenu.tsx
@@ -20,15 +20,6 @@ export const AdminMobileMenu: React.FC<Props> = ({ event }) => {
         <ListItemText primary="Admin" />
       </ListItem>
 
-      <Styled.NestedListItem button key="check_in_event">
-        <ListItemIcon>
-          <CheckIcon />
-        </ListItemIcon>
-        <Link href={`/${event?.abbr}/ui/admin/check_in_event`} rel="noreferrer">
-          <Button style={{ color: '#423A57' }}>Check-In (Event)</Button>
-        </Link>
-      </Styled.NestedListItem>
-
       <Styled.NestedListItem button key="check_in_session">
         <ListItemIcon>
           <CheckIcon />


### PR DESCRIPTION
## Summary
- AdminMobileMenu の Check-In (Event) メニュー項目を非表示にしました
- `/[eventAbbr]/ui/admin/check_in_event` ページ自体は残しているため、URL 直打ちでは引き続きアクセス可能です

## Test plan
- [ ] 管理者ユーザーでログインし、モバイルメニューに Check-In (Event) が表示されないことを確認
- [ ] Check-In (Session) は引き続き表示・遷移できることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)