### PR TITLE
feat: スポンサー担当者の Q&A 回答に対応 (API スキーマ + UI)

### DIFF
--- a/schemas/swagger.yml
+++ b/schemas/swagger.yml
@@ -1935,6 +1935,7 @@ components:
       title: "SessionQuestionsResponse"
       required:
         - "questions"
+        - "current_user_role"
       type: "object"
       properties:
         questions:

--- a/schemas/swagger.yml
+++ b/schemas/swagger.yml
@@ -1941,6 +1941,12 @@ components:
           type: "array"
           items:
             $ref: "#/components/schemas/SessionQuestion"
+        current_user_role:
+          type: "string"
+          nullable: true
+          enum:
+            - "speaker"
+            - "sponsor"
       additionalProperties: false
     SessionQuestion:
       title: "SessionQuestion"
@@ -2009,7 +2015,7 @@ components:
       required:
         - "id"
         - "body"
-        - "speaker"
+        - "answerer"
         - "created_at"
       type: "object"
       properties:
@@ -2017,11 +2023,26 @@ components:
           type: "integer"
         body:
           type: "string"
-        speaker:
-          $ref: "#/components/schemas/SpeakerInfo"
+        answerer:
+          $ref: "#/components/schemas/AnswererInfo"
         created_at:
           type: "string"
           format: "date-time"
+      additionalProperties: false
+    AnswererInfo:
+      title: "AnswererInfo"
+      required:
+        - "type"
+        - "name"
+      type: "object"
+      properties:
+        type:
+          type: "string"
+          enum:
+            - "speaker"
+            - "sponsor"
+        name:
+          type: "string"
       additionalProperties: false
     SessionQuestionAnswerCreateRequest:
       title: "SessionQuestionAnswerCreateRequest"

--- a/src/components/SessionQA/SessionQA.tsx
+++ b/src/components/SessionQA/SessionQA.tsx
@@ -282,13 +282,12 @@ export const SessionQA: React.FC<Props> = ({ talk }) => {
     [talk?.id, deleteQuestion],
   )
 
-  // スピーカー判定: Profile.userId と Talk.speakers[].userId を比較
-  // どちらも User.id を指すため、一致すれば現在のユーザーがこのトークの
-  // スピーカーであると判定できる。
-  const isSpeaker = useMemo(() => {
-    if (!talk || !profile?.userId) return false
-    return talk.speakers.some((speaker) => speaker.userId === profile.userId)
-  }, [talk, profile])
+  // 回答可否は API のレスポンス current_user_role で判定する
+  // ('speaker' or 'sponsor' なら回答可、null なら不可)
+  const canAnswer = useMemo(
+    () => questionsData?.current_user_role != null,
+    [questionsData?.current_user_role],
+  )
 
   // 常に質問可能
   const isVisibleForm = true
@@ -330,7 +329,7 @@ export const SessionQA: React.FC<Props> = ({ talk }) => {
         questions={questions}
         isLoading={isLoading}
         autoScroll={autoScroll}
-        isSpeaker={isSpeaker}
+        canAnswer={canAnswer}
         currentProfileId={profile?.id}
         onVote={handleVote}
         onAnswerSubmit={handleAnswerSubmit}

--- a/src/components/SessionQA/__tests__/SessionQA.spec.tsx
+++ b/src/components/SessionQA/__tests__/SessionQA.spec.tsx
@@ -31,8 +31,8 @@ const mockQuestions = {
         {
           id: 1,
           body: '回答1',
-          speaker: {
-            id: 1,
+          answerer: {
+            type: 'speaker',
             name: 'スピーカー1',
           },
           created_at: '2026-01-01T12:00:00Z',
@@ -40,6 +40,7 @@ const mockQuestions = {
       ],
     },
   ],
+  current_user_role: null,
 }
 
 const server = setupMockServer(

--- a/src/components/SessionQA/__tests__/SessionQA.spec.tsx
+++ b/src/components/SessionQA/__tests__/SessionQA.spec.tsx
@@ -110,4 +110,59 @@ describe('SessionQA', () => {
       expect(screen.getByText('質問1')).toBeInTheDocument()
     })
   })
+
+  describe.each([
+    { role: 'speaker' as const, label: 'speaker' },
+    { role: 'sponsor' as const, label: 'sponsor' },
+  ])(
+    'when current_user_role is $label',
+    ({ role }: { role: 'speaker' | 'sponsor' }) => {
+      it('should show "回答する" button', async () => {
+        server.use(
+          rest.get(`/api/v1/talks/:talkId/session_questions`, (_, res, ctx) => {
+            return res(
+              ctx.json({ ...mockQuestions, current_user_role: role }),
+            )
+          }),
+        )
+
+        const mockProps = {
+          event: MockEvent(),
+          talk: MockTalkA1(),
+        }
+
+        const store = setupStore()
+        store.dispatch(setProfile(MockProfile()))
+        store.dispatch(setWsBaseUrl('http://localhost:8080'))
+        const screen = renderWithProviders(<SessionQA {...mockProps} />, {
+          store,
+        })
+
+        await waitFor(() => {
+          expect(screen.getByText('質問1')).toBeInTheDocument()
+        })
+        // 質問の数だけ「回答する」ボタンが表示される
+        expect(screen.getAllByText('回答する').length).toBe(
+          mockQuestions.questions.length,
+        )
+      })
+    },
+  )
+
+  it('should not show "回答する" button when current_user_role is null', async () => {
+    const mockProps = {
+      event: MockEvent(),
+      talk: MockTalkA1(),
+    }
+
+    const store = setupStore()
+    store.dispatch(setProfile(MockProfile()))
+    store.dispatch(setWsBaseUrl('http://localhost:8080'))
+    const screen = renderWithProviders(<SessionQA {...mockProps} />, { store })
+
+    await waitFor(() => {
+      expect(screen.getByText('質問1')).toBeInTheDocument()
+    })
+    expect(screen.queryByText('回答する')).not.toBeInTheDocument()
+  })
 })

--- a/src/components/SessionQA/internal/AnswerItem/AnswerItem.tsx
+++ b/src/components/SessionQA/internal/AnswerItem/AnswerItem.tsx
@@ -14,7 +14,7 @@ export const AnswerItem: React.FC<Props> = ({ answer }) => {
   return (
     <Styled.Container>
       <Styled.AnswerHeader>
-        <Styled.SpeakerName>{answer.speaker.name}</Styled.SpeakerName>
+        <Styled.SpeakerName>{answer.answerer.name}</Styled.SpeakerName>
         <Styled.AnswerTime>
           {dayjs(answer.created_at).tz().format('HH:mm')}
         </Styled.AnswerTime>

--- a/src/components/SessionQA/internal/QuestionList/QuestionItem/QuestionItem.tsx
+++ b/src/components/SessionQA/internal/QuestionList/QuestionItem/QuestionItem.tsx
@@ -11,7 +11,7 @@ setupDayjs()
 
 type Props = {
   question: SessionQuestion
-  isSpeaker: boolean
+  canAnswer: boolean
   isOwnQuestion: boolean
   onVote: (questionId: number) => void
   onAnswerSubmit: (questionId: number, body: string) => void
@@ -20,7 +20,7 @@ type Props = {
 
 export const QuestionItem: React.FC<Props> = ({
   question,
-  isSpeaker,
+  canAnswer,
   isOwnQuestion,
   onVote,
   onAnswerSubmit,
@@ -85,7 +85,7 @@ export const QuestionItem: React.FC<Props> = ({
           ))}
         </Styled.AnswersContainer>
       )}
-      {isSpeaker && (
+      {canAnswer && (
         <Styled.AnswerSection>
           {!showAnswerForm ? (
             <Styled.ShowAnswerButton onClick={() => setShowAnswerForm(true)}>

--- a/src/components/SessionQA/internal/QuestionList/QuestionList.tsx
+++ b/src/components/SessionQA/internal/QuestionList/QuestionList.tsx
@@ -7,7 +7,7 @@ type Props = {
   questions: SessionQuestion[]
   isLoading: boolean
   autoScroll: boolean
-  isSpeaker: boolean
+  canAnswer: boolean
   currentProfileId?: number
   onVote: (questionId: number) => void
   onAnswerSubmit: (questionId: number, body: string) => void
@@ -18,7 +18,7 @@ export const QuestionList: React.FC<Props> = ({
   questions,
   isLoading,
   autoScroll,
-  isSpeaker,
+  canAnswer,
   currentProfileId,
   onVote,
   onAnswerSubmit,
@@ -54,7 +54,7 @@ export const QuestionList: React.FC<Props> = ({
         <QuestionItem
           key={question.id}
           question={question}
-          isSpeaker={isSpeaker}
+          canAnswer={canAnswer}
           isOwnQuestion={question.profile_id === currentProfileId}
           onVote={onVote}
           onAnswerSubmit={onAnswerSubmit}

--- a/src/generated/dreamkast-api.generated.ts
+++ b/src/generated/dreamkast-api.generated.ts
@@ -862,7 +862,7 @@ export type SessionQuestion = {
 }
 export type SessionQuestionsResponse = {
   questions: SessionQuestion[]
-  current_user_role?: (('speaker' | 'sponsor') | null) | undefined
+  current_user_role: ('speaker' | 'sponsor') | null
 }
 export type SessionQuestionCreateRequest = {
   body: string

--- a/src/generated/dreamkast-api.generated.ts
+++ b/src/generated/dreamkast-api.generated.ts
@@ -841,14 +841,14 @@ export type ProfilePointsResponse = {
 export type ErrorSchema = {
   message?: string | undefined
 }
-export type SpeakerInfo = {
-  id: number
+export type AnswererInfo = {
+  type: 'speaker' | 'sponsor'
   name: string
 }
 export type SessionQuestionAnswer = {
   id: number
   body: string
-  speaker: SpeakerInfo
+  answerer: AnswererInfo
   created_at: string
 }
 export type SessionQuestion = {
@@ -862,6 +862,7 @@ export type SessionQuestion = {
 }
 export type SessionQuestionsResponse = {
   questions: SessionQuestion[]
+  current_user_role?: (('speaker' | 'sponsor') | null) | undefined
 }
 export type SessionQuestionCreateRequest = {
   body: string


### PR DESCRIPTION
## Summary

dreamkast の [PR #2808](https://github.com/cloudnativedaysjp/dreamkast/pull/2808) (スポンサー担当者がセッション Q&A に回答できるようにする) の dreamkast-ui 側対応。

## 変更内容

- `schemas/swagger.yml`
  - `SessionQuestionAnswer.speaker` を `answerer` (`{ type: 'speaker' | 'sponsor', name: string }`) に変更
  - `AnswererInfo` を新規追加
  - `SessionQuestionsResponse` に `current_user_role` (`'speaker' | 'sponsor' | null`) を追加
- 生成型 (`dreamkast-api.generated.ts`) を再生成
- `SessionQA.tsx`: 回答フォームの表示可否を `talk.speakers` ベースの `isSpeaker` から API 由来の `current_user_role` ベースの `canAnswer` に変更
- `AnswerItem.tsx`: `answer.speaker.name` → `answer.answerer.name` に変更 (Speaker 名 / 「スポンサー担当者」を出し分け)
- `QuestionList.tsx` / `QuestionItem.tsx`: `isSpeaker` prop を `canAnswer` にリネーム
- 既存 jest テストも新形式に更新

## Test plan

- [ ] `yarn type-check` 通過
- [ ] `yarn jest src/components/SessionQA` (16/16 パス済み)
- [ ] dreamkast 側 PR #2808 と同時にデプロイし、視聴ページの Q&A タブで:
  - スピーカーは従来通り回答フォームが見える / 回答可能
  - スポンサー担当者は担当スポンサーの Talk のみ回答フォームが見える / 回答可能
  - それ以外のユーザーは回答フォームが表示されない
  - スポンサー担当者の回答は「スポンサー担当者」表示

🤖 Generated with [Claude Code](https://claude.com/claude-code)