### PR TITLE
fix(SessionQA): prettier 違反を修正してイメージビルドを通す

### DIFF
--- a/src/components/SessionQA/__tests__/SessionQA.spec.tsx
+++ b/src/components/SessionQA/__tests__/SessionQA.spec.tsx
@@ -120,9 +120,7 @@ describe('SessionQA', () => {
       it('should show "回答する" button', async () => {
         server.use(
           rest.get(`/api/v1/talks/:talkId/session_questions`, (_, res, ctx) => {
-            return res(
-              ctx.json({ ...mockQuestions, current_user_role: role }),
-            )
+            return res(ctx.json({ ...mockQuestions, current_user_role: role }))
           }),
         )
 


### PR DESCRIPTION
## Summary
- 直近の `4ad58bb` で追加された `SessionQA.spec.tsx` のテストが prettier ルールに違反しており、Docker イメージビルド (`yarn build`) が失敗していた ([failing run](https://github.com/cloudnativedaysjp/dreamkast-ui/actions/runs/25274908604))
- `ctx.json(...)` の不要な複数行折り返しを 1 行に整形して修正

## Test plan
- [x] `npx prettier --check src/components/SessionQA/__tests__/SessionQA.spec.tsx` がパスすること
- [ ] CI の `build` ジョブが green になること

🤖 Generated with [Claude Code](https://claude.com/claude-code)