### PR TITLE
fix(ci): build-tag.yml の無効な platforms 入力を削除

### DIFF
--- a/.github/workflows/build-tag.yml
+++ b/.github/workflows/build-tag.yml
@@ -12,7 +12,6 @@ jobs:
       id-token: write
     with:
       image_name: dreamkast-ui
-      platforms: amd64
       aws_region: ap-northeast-1
       run-trivy: false
       build_args: |


### PR DESCRIPTION
## Summary
- `cloudnativedaysjp/reusable-workflows/.github/workflows/wc-build-image.yml@main` が `platforms` 入力を受け付けず、ワークフローが `Invalid input, platforms is not defined in the referenced workflow` で失敗していたため修正。
- reusable workflow は内部マトリクスで `amd64`/`arm64` をビルドして multi-arch manifest にマージするようになっており、`platforms` 入力は不要。

## Test plan
- [ ] タグを push して `build container image when tags are pushed` ワークフローがバリデーションエラーなく起動することを確認
- [ ] `build` ジョブが amd64/arm64 両方ビルドし、merge ジョブが multi-arch manifest を作成することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)